### PR TITLE
Fix tab restore after wallet erase

### DIFF
--- a/lib/pages/main/main_screen.dart
+++ b/lib/pages/main/main_screen.dart
@@ -237,7 +237,12 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
   }
 
   Widget getMain() {
-    _controller.jumpToTab(applicationStore.currentTabIndex);
+    if (applicationStore.hasStoredWalletSettings) {
+      _controller.jumpToTab(applicationStore.currentTabIndex);
+    }
+    else {
+      _controller.jumpToTab(0);
+    }
     // _controller.jumpToPreviousTab();
     return PersistentTabView(
       controller: _controller,


### PR DESCRIPTION
- Go to Settings tab
- Erase the wallet
- Create a new wallet
 
 The tab should be reset to Home tab, instead of showing the Settings tab (due to the auto-tab-restore from auto-lock feature)

@sallymoc @Qubic-Hub 