### PR TITLE
Fix unvalidated password form

### DIFF
--- a/lib/pages/auth/sign_up.dart
+++ b/lib/pages/auth/sign_up.dart
@@ -185,9 +185,11 @@ class _ReceiveState extends State<SignUp> {
         validator: FormBuilderValidators.compose([
           FormBuilderValidators.required(
               errorText: l10n.generalErrorSetWalletPasswordRepeatEmpty),
-          (value) {
-            if (value == currentPassword) return null;
-            return l10n.generalErrorSetPasswordNotMatching;
+              (value) {
+            if (value != currentPassword) {
+              return l10n.generalErrorSetPasswordNotMatching;
+            }
+            return null;
           }
         ]),
         onSubmitted: (value) => handleProceed(),
@@ -214,6 +216,8 @@ class _ReceiveState extends State<SignUp> {
       ),
     ];
   }
+
+
 
   Widget getStep2() {
     final l10n = l10nOf(context);
@@ -287,8 +291,9 @@ class _ReceiveState extends State<SignUp> {
 
   //Handles form submission and navigation from create password to biometrics setup
   Future<void> step1ToStep2Submit() async {
-    _formKey.currentState?.validate();
-    if (!_formKey.currentState!.isValid) {
+    final formState = _formKey.currentState;
+    formState?.save(); // Save the form state
+    if (formState == null || !formState.validate()) {
       setState(() {
         isLoading = false;
       });
@@ -296,35 +301,39 @@ class _ReceiveState extends State<SignUp> {
     }
 
     showModalBottomSheet<void>(
-        context: context,
-        isScrollControlled: true,
-        useRootNavigator: true,
-        useSafeArea: true,
-        backgroundColor: LightThemeColors.background,
-        builder: (BuildContext context) {
-          return SafeArea(
-              child: CreatePasswordSheet(onAccept: () async {
-            if (totalSteps == 2) {
-              //Navigator.pop(context);
+      context: context,
+      isScrollControlled: true,
+      useRootNavigator: true,
+      useSafeArea: true,
+      backgroundColor: LightThemeColors.background,
+      builder: (BuildContext context) {
+        return SafeArea(
+          child: CreatePasswordSheet(
+            onAccept: () async {
+              if (totalSteps == 2) {
+                setState(() {
+                  stepNumber = 2;
+                  isLoading = false;
+                });
+              } else {
+                setState(() {
+                  isLoading = true;
+                  signUpError = null;
+                });
+                await submitFinalize();
+              }
+            },
+            onReject: () async {
               setState(() {
-                stepNumber = 2;
                 isLoading = false;
-              });
-            } else {
-              setState(() {
-                isLoading = true;
                 signUpError = null;
               });
-              await submitFinalize();
-            }
-          }, onReject: () async {
-            setState(() {
-              isLoading = false;
-              signUpError = null;
-            });
-            Navigator.pop(context);
-          }));
-        });
+              Navigator.pop(context);
+            },
+          ),
+        );
+      },
+    );
   }
 
   //Handles last step of sign up
@@ -371,9 +380,15 @@ class _ReceiveState extends State<SignUp> {
     if (!context.mounted) return;
     if (isLoading) return;
 
-    setState(() {
-      isLoading = true;
-    });
+    // Explicitly validate the form
+    final formState = _formKey.currentState;
+    if (formState == null || !formState.validate()) {
+      // If the form is not valid, stop the loading and prevent proceeding
+      setState(() {
+        isLoading = false;
+      });
+      return;
+    }
 
     if (stepNumber == 1) {
       if (totalSteps == 2) {


### PR DESCRIPTION
When create a new wallet, there will be two password forms. 

Previously they are not validated correctly, ie.
- The password can be less than 8 characters
- The repeat password form can be empty, or
- It can be even different from the first password form. 

This change will call the validation correctly.

@sallymoc @Qubic-Hub 

This is the new change:
![photo_2024-08-09 00 41 21](https://github.com/user-attachments/assets/b8c8c0f5-7e9d-4791-9f86-7a04f5f9b647)

Before:

https://github.com/user-attachments/assets/19486717-90e7-46b8-a9d0-a626dd1a03fb




