### PR TITLE
Add Watch Only to the account list

### DIFF
--- a/lib/components/account_list_item.dart
+++ b/lib/components/account_list_item.dart
@@ -45,11 +45,12 @@ class _AccountListItemState extends State<AccountListItem> {
   bool totalBalanceVisible = true;
   late ReactionDisposer _disposer;
 
+  bool isItemWatchOnly() => widget.item.watchOnly;
+
   @override
   void initState() {
     super.initState();
     totalBalanceVisible = _settingsStore.settings.totalBalanceVisible ?? true;
-
     _disposer = autorun((_) {
       setState(() {
         totalBalanceVisible = _settingsStore.totalBalanceVisible;
@@ -283,10 +284,11 @@ class _AccountListItemState extends State<AccountListItem> {
                         widget.item.amount != null && widget.item.amount! > 0,
                     child: Text(l10n.accountButtonViewInExplorer),
                   ),
-                  PopupMenuItem<CardItem>(
-                    value: CardItem.reveal,
-                    child: Text(l10n.accountButtonRevealPrivateSeed),
-                  ),
+                  if (!isItemWatchOnly()) // Check if item is not watch-only
+                    PopupMenuItem<CardItem>(
+                      value: CardItem.reveal,
+                      child: Text(l10n.accountButtonRevealPrivateSeed),
+                    ),
                   PopupMenuItem<CardItem>(
                     value: CardItem.rename,
                     child: Text(l10n.generalButtonRename),
@@ -307,52 +309,68 @@ class _AccountListItemState extends State<AccountListItem> {
       overflowButtonSpacing: ThemePaddings.smallPadding,
       buttonPadding: const EdgeInsets.fromLTRB(ThemeFontSizes.large,
           ThemeFontSizes.large, ThemeFontSizes.large, ThemeFontSizes.large),
-      children: [
-        widget.item.amount != null
-            ? ThemedControls.primaryButtonBig(
+      children: isItemWatchOnly()
+          ? [
+              const Row(
+                children: [
+                  Icon(
+                    Icons.remove_red_eye_rounded,
+                    color: LightThemeColors.color4,
+                  ),
+                  SizedBox(width: 6),
+                  Text("Watch Only",
+                      style: TextStyle(color: LightThemeColors.color4)),
+                ],
+              ),
+            ]
+          : [
+              widget.item.amount != null //&& widget.item.
+                  ? ThemedControls.primaryButtonBig(
+                      onPressed: () {
+                        // Perform some action
+                        pushScreen(
+                          context,
+                          screen: Send(item: widget.item),
+                          withNavBar: false, // OPTIONAL VALUE. True by default.
+                          pageTransitionAnimation:
+                              PageTransitionAnimation.cupertino,
+                        );
+                      },
+                      text: l10n.accountButtonSend,
+                      icon: LightThemeColors.shouldInvertIcon
+                          ? ThemedControls.invertedColors(
+                              child: Image.asset("assets/images/send.png"))
+                          : Image.asset("assets/images/send.png"))
+                  : Container(),
+              ThemedControls.primaryButtonBig(
                 onPressed: () {
-                  // Perform some action
                   pushScreen(
                     context,
-                    screen: Send(item: widget.item),
+                    screen: Receive(item: widget.item),
                     withNavBar: false, // OPTIONAL VALUE. True by default.
                     pageTransitionAnimation: PageTransitionAnimation.cupertino,
                   );
                 },
-                text: l10n.accountButtonSend,
-                icon: LightThemeColors.shouldInvertIcon
+                icon: !LightThemeColors.shouldInvertIcon
                     ? ThemedControls.invertedColors(
-                        child: Image.asset("assets/images/send.png"))
-                    : Image.asset("assets/images/send.png"))
-            : Container(),
-        ThemedControls.primaryButtonBig(
-          onPressed: () {
-            pushScreen(
-              context,
-              screen: Receive(item: widget.item),
-              withNavBar: false, // OPTIONAL VALUE. True by default.
-              pageTransitionAnimation: PageTransitionAnimation.cupertino,
-            );
-          },
-          icon: !LightThemeColors.shouldInvertIcon
-              ? ThemedControls.invertedColors(
-                  child: Image.asset("assets/images/receive.png"))
-              : Image.asset("assets/images/receive.png"),
-          text: l10n.accountButtonReceive,
-        ),
-        widget.item.assets.keys.isNotEmpty
-            ? ThemedControls.primaryButtonBig(
-                text: l10n.accountButtonAssets,
-                onPressed: () {
-                  pushScreen(
-                    context,
-                    screen: Assets(PublicId: widget.item.publicId),
-                    withNavBar: false, // OPTIONAL VALUE. True by default.
-                    pageTransitionAnimation: PageTransitionAnimation.cupertino,
-                  );
-                })
-            : Container()
-      ],
+                        child: Image.asset("assets/images/receive.png"))
+                    : Image.asset("assets/images/receive.png"),
+                text: l10n.accountButtonReceive,
+              ),
+              widget.item.assets.keys.isNotEmpty
+                  ? ThemedControls.primaryButtonBig(
+                      text: l10n.accountButtonAssets,
+                      onPressed: () {
+                        pushScreen(
+                          context,
+                          screen: Assets(PublicId: widget.item.publicId),
+                          withNavBar: false, // OPTIONAL VALUE. True by default.
+                          pageTransitionAnimation:
+                              PageTransitionAnimation.cupertino,
+                        );
+                      })
+                  : Container(),
+            ],
     );
   }
 

--- a/lib/models/critical_settings.dart
+++ b/lib/models/critical_settings.dart
@@ -26,6 +26,8 @@ class CriticalSettings {
   /// The derivation index for the generated Ids
   late int derivationIndex;
 
+  late List<bool> isWatchOnly;
+
   CriticalSettings(
       {required this.storedPasswordHash,
       required this.publicIds,
@@ -35,6 +37,7 @@ class CriticalSettings {
       this.mnemonic,
       this.idsGeneratedFromMnemonic = const []}) {
     padding ??= _generateRandomString();
+    isWatchOnly = privateSeeds.map((seed) => seed == '-1').toList();
   }
 
   String _generateRandomString() {

--- a/lib/models/qubic_id.dart
+++ b/lib/models/qubic_id.dart
@@ -5,6 +5,7 @@ class QubicId {
   late String _publicId; //The public ID
   late String _name; //A descriptive name of the ID
   late double? _amount; //The amount of the ID
+  late bool _watchOnly; // This ID is watch only, means _privateSeed = -1
 
   factory QubicId.fromJson(Map<String, dynamic> json) {
     var privateSeed = json['privateSeed'];
@@ -19,6 +20,7 @@ class QubicId {
     _publicId = publicId.replaceAll(",", "_");
     _name = name.replaceAll(",", "_");
     _amount = amount;
+    _watchOnly = _privateSeed == '-1' ? true : false;
   }
 
   double? getAmount() {
@@ -27,6 +29,7 @@ class QubicId {
 
   void setPrivateSeed(String? privateSeed) {
     _privateSeed = privateSeed?.replaceAll(",", "_");
+    _watchOnly = _privateSeed == '-1' ? true : false;
   }
 
   void setPublicId(String publicId) {
@@ -48,4 +51,6 @@ class QubicId {
   getName() {
     return _name;
   }
+
+  isWatchOnly() => _watchOnly;
 }

--- a/lib/models/qubic_list_vm.dart
+++ b/lib/models/qubic_list_vm.dart
@@ -20,10 +20,14 @@ class QubicListVm {
   @observable
   late bool? hasPendingTransaction;
 
+  @observable
+  late bool watchOnly;
+
   QubicListVm(String publicId, String name, this.amount, this.amountTick,
-      Map<String, QubicAssetDto>? assets) {
+      Map<String, QubicAssetDto>? assets, this.watchOnly) {
     _publicId = publicId.replaceAll(",", "_");
     _name = name.replaceAll(",", "_");
+
     this.assets.clear();
     if (assets != null) {
       this.assets.addAll(assets);
@@ -95,6 +99,7 @@ class QubicListVm {
         original.name,
         original.amount,
         original.amountTick,
-        Map<String, QubicAssetDto>.from(original.getClonedAssets()));
+        Map<String, QubicAssetDto>.from(original.getClonedAssets()),
+        original.watchOnly);
   }
 }

--- a/lib/pages/main/tab_wallet_contents.dart
+++ b/lib/pages/main/tab_wallet_contents.dart
@@ -39,6 +39,7 @@ class _TabWalletContentsState extends State<TabWalletContents> {
   final bool showTickOnTop = false;
   final ScrollController _scrollController = ScrollController();
   String? signInError;
+
   // int? currentTick;
 
   ReactionDisposer? disposeAutorun;
@@ -137,7 +138,9 @@ class _TabWalletContentsState extends State<TabWalletContents> {
                       onPressed: () {
                         pushScreen(
                           context,
-                          screen: const AddAccount(),
+                          screen: const AddAccount(
+                            isWatchOnly: false,
+                          ),
                           withNavBar: false, // OPTIONAL VALUE. True by default.
                           pageTransitionAnimation:
                               PageTransitionAnimation.cupertino,
@@ -168,11 +171,120 @@ class _TabWalletContentsState extends State<TabWalletContents> {
           });
       return;
     }
-    pushScreen(
-      context,
-      screen: const AddAccount(),
-      withNavBar: false, // OPTIONAL VALUE. True by default.
-      pageTransitionAnimation: PageTransitionAnimation.cupertino,
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext context) {
+        return FractionallySizedBox(
+          heightFactor: 0.4,
+          child: SafeArea(
+            child: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(
+                    ThemePaddings.normalPadding,
+                    ThemePaddings.normalPadding,
+                    ThemePaddings.normalPadding,
+                    0),
+                child: Column(
+                  mainAxisSize: MainAxisSize.max,
+                  children: [
+                    Container(
+                      constraints:
+                          const BoxConstraints(minWidth: 400, maxWidth: 500),
+                      child: Card(
+                        color: LightThemeColors.cardBackground,
+                        elevation: 0,
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(
+                              ThemePaddings.normalPadding,
+                              ThemePaddings.normalPadding,
+                              ThemePaddings.normalPadding,
+                              0),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              ListTile(
+                                leading: Icon(Icons.account_circle),
+                                title: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text("Create New Account",
+                                        style: TextStyles.labelText.copyWith()),
+                                    Text("Add new Qubic account",
+                                        style: TextStyles.textNormal.copyWith())
+                                  ],
+                                ),
+                                onTap: () {
+                                  Navigator.pop(context);
+                                  pushScreen(
+                                    context,
+                                    screen:
+                                        const AddAccount(isWatchOnly: false),
+                                    withNavBar: false,
+                                    pageTransitionAnimation:
+                                        PageTransitionAnimation.cupertino,
+                                  );
+                                },
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                    Container(
+                      constraints:
+                          const BoxConstraints(minWidth: 400, maxWidth: 500),
+                      child: Card(
+                        color: LightThemeColors.cardBackground,
+                        elevation: 0,
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(
+                              ThemePaddings.normalPadding,
+                              ThemePaddings.normalPadding,
+                              ThemePaddings.normalPadding,
+                              0),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              ListTile(
+                                leading: Icon(Icons.visibility),
+                                title: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      "Watch only address",
+                                      style: TextStyles.labelText,
+                                    ),
+                                    Text(
+                                      "Track a Qubic public address",
+                                      style: TextStyles.textNormal.copyWith(),
+                                    ),
+                                  ],
+                                ),
+                                onTap: () {
+                                  Navigator.pop(context);
+                                  pushScreen(
+                                    context,
+                                    screen: const AddAccount(isWatchOnly: true),
+                                    withNavBar: false,
+                                    pageTransitionAnimation:
+                                        PageTransitionAnimation.cupertino,
+                                  );
+                                },
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 

--- a/lib/resources/secure_storage.dart
+++ b/lib/resources/secure_storage.dart
@@ -229,7 +229,8 @@ class SecureStorage {
     List<QubicListVm> list = [];
     for (int i = 0; i < settings.publicIds.length; i++) {
       list.add(QubicListVm(
-          settings.publicIds[i], settings.names[i], null, null, null));
+          settings.publicIds[i], settings.names[i], null, null, null,
+          settings.isWatchOnly[i]));
     }
     return list;
   }
@@ -288,7 +289,7 @@ class SecureStorage {
       throw Exception("ID not found");
     }
     return QubicId(settings.privateSeeds[i], settings.publicIds[i],
-        settings.names[i], null);
+          settings.names[i], null);
   }
 
   //Removes a Qubic ID from the secure Storage (Based on its public key)

--- a/lib/stores/application_store.dart
+++ b/lib/stores/application_store.dart
@@ -66,14 +66,18 @@ abstract class _ApplicationStore with Store {
 
   @computed
   int get totalAmounts {
-    return currentQubicIDs.fold<int>(
+    return currentQubicIDs
+        .where((qubic) => !qubic.watchOnly)
+        .fold<int>(
         0, (sum, qubic) => sum + (qubic.amount ?? 0));
   }
 
   @computed
   double get totalAmountsInUSD {
     if (marketInfo == null) return -1;
-    return currentQubicIDs.fold<double>(0,
+    return currentQubicIDs
+        .where((qubic) => !qubic.watchOnly)
+        .fold<double>(0,
         (sum, qubic) => sum + (qubic.amount ?? 0) * marketInfo!.priceAsDouble);
   }
 
@@ -85,7 +89,9 @@ abstract class _ApplicationStore with Store {
   List<QubicAssetDto> get totalShares {
     List<QubicAssetDto> shares = [];
     List<QubicAssetDto> tokens = [];
-    currentQubicIDs.forEach((id) {
+    currentQubicIDs
+        .where((qubic) => !qubic.watchOnly)
+        .forEach((id) {
       id.assets.forEach((key, asset) {
         QubicAssetDto temp = asset.clone();
         temp.ownedAmount ??= 0;
@@ -235,7 +241,8 @@ abstract class _ApplicationStore with Store {
     await secureStorage.addManyIds(ids);
     for (var element in ids) {
       currentQubicIDs.add(QubicListVm(
-          element.getPublicId(), element.getName(), null, null, null));
+          element.getPublicId(), element.getName(), null, null, null,
+          element.getPrivateSeed() == '-1' ? true : false));
     }
   }
 
@@ -244,12 +251,13 @@ abstract class _ApplicationStore with Store {
     //Todo store in wallet
 
     await secureStorage.addID(QubicId(privateSeed, publicId, name, null));
-    currentQubicIDs.add(QubicListVm(publicId, name, null, null, null));
+    currentQubicIDs.add(QubicListVm(publicId, name, null, null, null,
+      privateSeed == '-1' ? true : false));
   }
 
   Future<String> getSeedById(String publicId) async {
-    var result = await secureStorage.getIdByPublicKey(publicId);
-    return result.getPrivateSeed();
+      var result = await secureStorage.getIdByPublicKey(publicId);
+      return result.getPrivateSeed();
   }
 
   @action
@@ -262,8 +270,6 @@ abstract class _ApplicationStore with Store {
         await secureStorage.renameId(publicId, name);
         return;
       }
-
-      //currentQubicIDs.forEach((element) {
     } //);
   }
 


### PR DESCRIPTION
My solution is to give these watch only accounts private seed -1. By marking that, all watch only accounts will be excluded from counting the wallet's total amounts/assets. They don't have the button Send/Receive, and Reveal Seed in the context menu list. The user can see the transfers, the total amount of each watch only account individually.

Addressing issue https://github.com/qubic/wallet-app/issues/49

