### PR TITLE
Fix app getting stuck during vault export by removing unnecessary state updates

### DIFF
--- a/lib/pages/main/wallet_contents/settings/export_wallet_vault.dart
+++ b/lib/pages/main/wallet_contents/settings/export_wallet_vault.dart
@@ -349,10 +349,6 @@ class _ExportWalletVaultState extends State<ExportWalletVault> {
     if (isLoading) {
       return;
     }
-    setState(() {
-      emptyPathError = false;
-      isLoading = true;
-    });
     _formKey.currentState?.validate();
     if ((selectedPath == null) && (!useShareController)) {
       setState(() {


### PR DESCRIPTION
This pull request fixes the issue where the macOS app would get stuck when trying to export the vault file with an empty path selection, as discussed in [#95](https://github.com/qubic/wallet-app/issues/95).

- The app now properly detects when the path selection is missing and prevents the export process from starting.

Fixes #95 