### PR TITLE
Multiple fix for transactions

### DIFF
--- a/lib/components/transaction_resend.dart
+++ b/lib/components/transaction_resend.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:qubic_wallet/components/amount_formatted.dart';
 import 'package:qubic_wallet/components/currency_label.dart';
 import 'package:qubic_wallet/components/transaction_details.dart';
 import 'package:qubic_wallet/di.dart';
@@ -43,11 +44,7 @@ class TransactionResend extends StatelessWidget {
         return Container(
             width: double.infinity,
             child: Text(l10n.generalLabelToFromAddress(prepend),
-                textAlign: TextAlign.start,
-                style: Theme.of(context)
-                    .textTheme
-                    .titleLarge!
-                    .copyWith(fontFamily: ThemeFonts.primary)));
+                style: TextStyles.labelText));
       }),
       Text(id,
           style: Theme.of(context)
@@ -86,21 +83,10 @@ class TransactionResend extends StatelessWidget {
                 isInHeader: false,
                 style: TextStyles.accountAmountLabel)
           ]),
+          const SizedBox(height: ThemePaddings.normalPadding),
           getFromTo(context, l10n.generalLabelFrom, item.sourceId),
-          const SizedBox(height: ThemePaddings.smallPadding),
-          getFromTo(context, l10n.generalLabelTo, item.destId),
-          const SizedBox(height: ThemePaddings.smallPadding),
-          Container(
-              width: double.infinity,
-              child: Text(l10n.sendItemLabelTargetTick,
-                  textAlign: TextAlign.start, style: TextStyles.labelText)),
-          Observer(builder: (context) {
-            return Text(
-                l10n.sendItemLabelResendTargetTickValue(
-                    (appStore.currentTick + 20).asThousands(),
-                    appStore.currentTick.asThousands()),
-                style: TextStyles.textNormal);
-          })
+          const SizedBox(height: ThemePaddings.normalPadding),
+          getFromTo(context, l10n.generalLabelTo, item.destId)
         ]));
   }
 }

--- a/lib/helpers/target_tick.dart
+++ b/lib/helpers/target_tick.dart
@@ -1,0 +1,15 @@
+enum TargetTickTypeEnum {
+  autoCurrentPlus5(5),
+  autoCurrentPlus10(10),
+  autoCurrentPlus20(20),
+  autoCurrentPlus40(40),
+  manual(-1);
+
+  // This is the property that will hold the value
+  final int value;
+
+  // A constructor for the enum
+  const TargetTickTypeEnum(this.value);
+}
+
+TargetTickTypeEnum defaultTargetTickType = TargetTickTypeEnum.autoCurrentPlus5;

--- a/lib/helpers/tickPercentage.dart
+++ b/lib/helpers/tickPercentage.dart
@@ -1,3 +1,0 @@
-String getTickPercentage(double total, double faultyTicks) {
-  return ((total - faultyTicks) / (total)).toStringAsFixed(2);
-}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -76,7 +76,14 @@
     "generalSnackBarMessageWalletDataErased": "Wallet-Daten vom Gerät gelöscht.",
     "generalSnackBarMessageQRScannedWithSuccess": "QR-Code erfolgreich gescannt.",
     "generalSnackBarMessageAccountAlreadyExist": "Dieses Konto existiert bereits in Ihrer Wallet.",
-    "generalSnackBarMessageTransactionSubmitted": "Neue Transaktion an das Qubic-Netzwerk übermittelt.",
+    "generalSnackBarMessageTransactionSubmitted": "Ihre Transaktion wurde zur Verbreitung im Tick {tick} gespeichert.",
+    "@generalSnackBarMessageTransactionSubmitted": {
+        "placeholders": {
+            "tick": {
+                "type": "String"
+            }
+        }
+    },
     "generalErrorUnsupportedOS": "Betriebssystem wird nicht unterstützt.",
     "generalErrorOnlyLowercaseChar": "Darf nur Kleinbuchstaben enthalten.",
     "generalErrorOnlyUppercaseChar": "Darf nur Großbuchstaben enthalten.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -76,7 +76,14 @@
     "generalSnackBarMessageWalletDataErased": "Wallet data erased from device",
     "generalSnackBarMessageQRScannedWithSuccess": "Successfully scanned QR Code",
     "generalSnackBarMessageAccountAlreadyExist": "This account already exists in your wallet",
-    "generalSnackBarMessageTransactionSubmitted": "Submitted new transaction to Qubic network",
+    "generalSnackBarMessageTransactionSubmitted": "Your transaction has been stored for propagation in tick {tick}.",
+    "@generalSnackBarMessageTransactionSubmitted": {
+        "placeholders": {
+            "tick": {
+                "type": "String"
+            }
+        }
+    },
     "generalErrorUnsupportedOS": "OS not supported",
     "generalErrorOnlyLowercaseChar": "Must contain only lowercase letters.",
     "generalErrorOnlyUppercaseChar": "Must contain only uppercase letters.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -76,7 +76,14 @@
     "generalSnackBarMessageWalletDataErased": "Datos del Wallet eliminados del dispositivo",
     "generalSnackBarMessageQRScannedWithSuccess": "Se escaneó el código QR con éxito",
     "generalSnackBarMessageAccountAlreadyExist": "Esta cuenta ya existe en el Wallet",
-    "generalSnackBarMessageTransactionSubmitted": "Nueva transacción enviada a la red Qubic",
+    "generalSnackBarMessageTransactionSubmitted": "Tu transacción se ha guardado y será enviada en el tick {tick}",
+    "@generalSnackBarMessageTransactionSubmitted": {
+        "placeholders": {
+            "tick": {
+                "type": "String"
+            }
+        }
+    },
     "generalErrorUnsupportedOS": "Sistema no soportado",
     "generalErrorOnlyLowercaseChar": "Debe contener sólo letras mayúsculas",
     "generalErrorOnlyUppercaseChar": "Debe contener sólo letras minúsculas",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -76,7 +76,14 @@
     "generalSnackBarMessageWalletDataErased": "Données du portefeuille effacées de l'appareil",
     "generalSnackBarMessageQRScannedWithSuccess": "QR Code scanné avec succès",
     "generalSnackBarMessageAccountAlreadyExist": "Ce compte existe déjà dans votre portefeuille",
-    "generalSnackBarMessageTransactionSubmitted": "Nouvelle transaction soumise au réseau Qubic",
+    "generalSnackBarMessageTransactionSubmitted": "Votre transaction a été enregistrée pour la propagation dans tick {tick}",
+    "@generalSnackBarMessageTransactionSubmitted": {
+        "placeholders": {
+            "tick": {
+                "type": "String"
+            }
+        }
+    },
     "generalErrorUnsupportedOS": "Système d'exploitation non pris en charge",
     "generalErrorOnlyLowercaseChar": "Doit contenir uniquement des lettres minuscules.",
     "generalErrorOnlyUppercaseChar": "Doit contenir uniquement des lettres majuscules.",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -76,7 +76,14 @@
     "generalSnackBarMessageWalletDataErased": "Данные кошелька удалены с устройства",
     "generalSnackBarMessageQRScannedWithSuccess": "QR код отсканирован успешно",
     "generalSnackBarMessageAccountAlreadyExist": "Этот аккаунт уже существует в кошельке",
-    "generalSnackBarMessageTransactionSubmitted": "Отправка новой транзакции в сеть Qubic",
+    "generalSnackBarMessageTransactionSubmitted": "Ваша транзакция была сохранена для тика {tick}",
+    "@generalSnackBarMessageTransactionSubmitted": {
+        "placeholders": {
+            "tick": {
+                "type": "String"
+            }
+        }
+    },
     "generalErrorUnsupportedOS": "ОС не поддерживается",
     "generalErrorOnlyLowercaseChar": "Должны быть только строчные буквы.",
     "generalErrorOnlyUppercaseChar": "Должны быть только заглавные буквы.",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -76,7 +76,14 @@
     "generalSnackBarMessageWalletDataErased": "Cüzdan verisi cihazdan silindi",
     "generalSnackBarMessageQRScannedWithSuccess": "QR kod başarılı bir şekilde tarandı",
     "generalSnackBarMessageAccountAlreadyExist": "Bu hesap zaten cüdanında mevcut",
-    "generalSnackBarMessageTransactionSubmitted": "Qubic ağına yeni işlem gönderildi",
+    "generalSnackBarMessageTransactionSubmitted": "İşleminiz yayılmak üzere {tick} kodlu Tick'te saklandı",
+    "@generalSnackBarMessageTransactionSubmitted": {
+        "placeholders": {
+            "tick": {
+                "type": "String"
+            }
+        }
+    },
     "generalErrorUnsupportedOS": "Bu işletim sistemi desteklenmiyor",
     "generalErrorOnlyLowercaseChar": "Yalnızca küçük harfler içermelidir.",
     "generalErrorOnlyUppercaseChar": "Yalnızca büyük harfler içermelidir.",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -76,7 +76,14 @@
     "generalSnackBarMessageWalletDataErased": "钱包数据已从设备中删除",
     "generalSnackBarMessageQRScannedWithSuccess": "成功扫描二维码",
     "generalSnackBarMessageAccountAlreadyExist": "您的钱包中已存在此帐户",
-    "generalSnackBarMessageTransactionSubmitted": "向 Qubic 网络提交新交易",
+    "generalSnackBarMessageTransactionSubmitted": "您的交易已被存储以便在 tick 中传播 {tick}",
+    "@generalSnackBarMessageTransactionSubmitted": {
+        "placeholders": {
+            "tick": {
+                "type": "String"
+            }
+        }
+    },
     "generalErrorUnsupportedOS": "系统不支持",
     "generalErrorOnlyLowercaseChar": "只包含小写字母。",
     "generalErrorOnlyUppercaseChar": "只包含大写字母。",

--- a/lib/pages/auth/create_password_sheet.dart
+++ b/lib/pages/auth/create_password_sheet.dart
@@ -64,7 +64,6 @@ class _CreatePasswordSheetState extends State<CreatePasswordSheet> {
     ]);
   }
 
-//transferNowHandler
   List<Widget> getButtons() {
     final l10n = l10nOf(context);
 

--- a/lib/pages/auth/erase_wallet_sheet.dart
+++ b/lib/pages/auth/erase_wallet_sheet.dart
@@ -66,7 +66,6 @@ class _EraseWalletSheetState extends State<EraseWalletSheet> {
     ]);
   }
 
-//transferNowHandler
   List<Widget> getButtons() {
     final l10n = l10nOf(context);
 

--- a/lib/pages/main/wallet_contents/add_account_warning_sheet.dart
+++ b/lib/pages/main/wallet_contents/add_account_warning_sheet.dart
@@ -77,7 +77,7 @@ class _AddAccountWarningSheetState extends State<AddAccountWarningSheet> {
       Expanded(
           child: hasAccepted
               ? ThemedControls.primaryButtonBigWithChild(
-                  onPressed: transferNowHandler,
+                  onPressed: proceedHandler,
                   child: Padding(
                     padding:
                         const EdgeInsets.all(ThemePaddings.smallPadding + 3),
@@ -95,7 +95,7 @@ class _AddAccountWarningSheetState extends State<AddAccountWarningSheet> {
     ];
   }
 
-  void transferNowHandler() async {
+  void proceedHandler() async {
     if (!hasAccepted) {
       return;
     }

--- a/lib/pages/main/wallet_contents/reveal_seed/reveal_seed_warning_sheet.dart
+++ b/lib/pages/main/wallet_contents/reveal_seed/reveal_seed_warning_sheet.dart
@@ -81,14 +81,13 @@ class _RevealSeedWarningSheetState extends State<RevealSeedWarningSheet> {
       Expanded(
           child: hasAccepted
               ? ThemedControls.primaryButtonBigPadded(
-                  onPressed: transferNowHandler,
-                  text: l10n.generalButtonProceed)
+                  onPressed: proceedHandler, text: l10n.generalButtonProceed)
               : ThemedControls.primaryButtonBigDisabledPadded(
                   text: l10n.generalButtonProceed)),
     ];
   }
 
-  void transferNowHandler() async {
+  void proceedHandler() async {
     if (!hasAccepted) {
       return;
     }

--- a/lib/pages/main/wallet_contents/send.dart
+++ b/lib/pages/main/wallet_contents/send.dart
@@ -14,6 +14,7 @@ import 'package:qubic_wallet/helpers/re_auth_dialog.dart';
 import 'package:qubic_wallet/helpers/sendTransaction.dart';
 import 'package:qubic_wallet/helpers/global_snack_bar.dart';
 import 'package:qubic_wallet/models/qubic_list_vm.dart';
+import 'package:qubic_wallet/resources/qubic_li.dart';
 import 'package:qubic_wallet/stores/application_store.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:intl/intl.dart';
@@ -23,17 +24,7 @@ import 'package:qubic_wallet/styles/text_styles.dart';
 import 'package:qubic_wallet/styles/themed_controls.dart';
 import 'package:qubic_wallet/timed_controller.dart';
 import 'package:qubic_wallet/l10n/l10n.dart';
-
-enum TargetTickType {
-  autoCurrentPlus20,
-  autoCurrentPlus40,
-  autoCurrentPlus60,
-  manual
-}
-
-const int autoCurrentPlus20Value = 20;
-const int autoCurrentPlus40Value = 40;
-const int autoCurrentPlus60Value = 60;
+import 'package:qubic_wallet/helpers/target_tick.dart';
 
 class Send extends StatefulWidget {
   final QubicListVm item;
@@ -47,13 +38,11 @@ class Send extends StatefulWidget {
 class _SendState extends State<Send> {
   final _formKey = GlobalKey<FormBuilderState>();
   final ApplicationStore appStore = getIt<ApplicationStore>();
+  final QubicLi apiService = getIt<QubicLi>();
   final TimedController _timedController = getIt<TimedController>();
   final GlobalSnackBar _globalSnackBar = getIt<GlobalSnackBar>();
-  int targetTick = 0;
-  int? frozenTargetTick;
-  int? frozenCurrentTick;
   String? transferError;
-  TargetTickType targetTickType = TargetTickType.autoCurrentPlus20;
+  TargetTickTypeEnum targetTickType = defaultTargetTickType;
 
   final NumberFormat formatter = NumberFormat.decimalPatternDigits(
     locale: 'en_us',
@@ -62,26 +51,21 @@ class _SendState extends State<Send> {
 
   bool expanded = false;
 
-  List<DropdownMenuItem<TargetTickType>> getTickList() {
+  List<DropdownMenuItem<TargetTickTypeEnum>> getTickList() {
     final l10n = l10nOf(context);
 
-    return [
-      DropdownMenuItem(
-          value: TargetTickType.autoCurrentPlus20,
-          child: Text(
-              l10n.sendItemLabelTargetTickAutomatic(autoCurrentPlus20Value))),
-      DropdownMenuItem(
-          value: TargetTickType.autoCurrentPlus40,
-          child: Text(
-              l10n.sendItemLabelTargetTickAutomatic(autoCurrentPlus40Value))),
-      DropdownMenuItem(
-          value: TargetTickType.autoCurrentPlus60,
-          child: Text(
-              l10n.sendItemLabelTargetTickAutomatic(autoCurrentPlus60Value))),
-      DropdownMenuItem(
-          value: TargetTickType.manual,
-          child: Text(l10n.sendItemLabelTargetTickManual))
-    ];
+    return TargetTickTypeEnum.values.map((targetTickTypeItem) {
+      return DropdownMenuItem<TargetTickTypeEnum>(
+        value: targetTickTypeItem,
+        child: Text(
+            targetTickTypeItem == TargetTickTypeEnum.manual
+                ? l10n.sendItemLabelTargetTickManual
+                : l10n
+                    .sendItemLabelTargetTickAutomatic(targetTickTypeItem.value),
+            style: TextStyles
+                .inputBoxSmallStyle), // Display name without enum prefix
+      );
+    }).toList();
   }
 
   CurrencyInputFormatter getInputFormatter() {
@@ -148,8 +132,6 @@ class _SendState extends State<Send> {
   }
 
   void showQRScanner() {
-    final l10n = l10nOf(context);
-
     showModalBottomSheet<void>(
         context: context,
         useSafeArea: true,
@@ -277,34 +259,10 @@ class _SendState extends State<Send> {
         });
   }
 
-  Widget getAdvancedRadio(TargetTickType type, String label) {
-    return InkWell(
-        onTap: () {
-          setState(() {
-            targetTickType = type;
-          });
-        },
-        child: Ink(
-            child: ListTile(
-                dense: true,
-                minVerticalPadding: ThemePaddings.miniPadding,
-                subtitle: Row(children: [
-                  Radio<TargetTickType>(
-                      value: type,
-                      groupValue: targetTickType,
-                      onChanged: (TargetTickType? value) {
-                        setState(() {
-                          targetTickType = value ?? type;
-                        });
-                      }),
-                  Text(label)
-                ]))));
-  }
-
   List<Widget> getOverrideTick() {
     final l10n = l10nOf(context);
 
-    if ((targetTickType == TargetTickType.manual) && (expanded == true)) {
+    if ((targetTickType == TargetTickTypeEnum.manual) && (expanded == true)) {
       return [
         ThemedControls.spacerVerticalSmall(),
         Row(
@@ -313,20 +271,14 @@ class _SendState extends State<Send> {
             Expanded(
                 child: Text(l10n.generalLabelTick,
                     style: TextStyles.labelTextNormal)),
-            ThemedControls.transparentButtonBigWithChild(
-                child: Observer(builder: (context) {
-              return Text(
-                  l10n.sendItemButtonSetCurrentTick(
-                      appStore.currentTick.asThousands()),
-                  style: TextStyles.transparentButtonText);
-            }), onPressed: () {
-              if (widget.item.amount == null) {
-                return;
-              }
-              if (widget.item.amount! > 0) {
-                tickController.text = appStore.currentTick.toString();
-              }
-            }),
+            ThemedControls.transparentButtonSmall(
+                text: l10n.sendItemButtonSetCurrentTick(
+                    appStore.currentTick.asThousands()),
+                onPressed: () {
+                  if (appStore.currentTick > 0) {
+                    tickController.text = appStore.currentTick.toString();
+                  }
+                }),
           ],
         ),
         FormBuilderTextField(
@@ -350,53 +302,6 @@ class _SendState extends State<Send> {
     return [Container()];
   }
 
-  Widget getAutoTick() {
-    final l10n = l10nOf(context);
-    if (targetTickType != TargetTickType.manual) {
-      return Column(
-          mainAxisSize: MainAxisSize.max,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            ThemedControls.spacerVerticalNormal(),
-            Text(l10n.sendItemLabelTargetTick,
-                style: TextStyles.labelTextNormal),
-            ThemedControls.spacerVerticalMini(),
-            ThemedControls.inputboxlikeLabel(
-                child: Observer(builder: (context) {
-              int tick = 0;
-              if (frozenTargetTick != null) {
-                tick = frozenTargetTick!;
-              } else {
-                if (targetTickType == TargetTickType.autoCurrentPlus20) {
-                  tick = appStore.currentTick + 20;
-                }
-                if (targetTickType == TargetTickType.autoCurrentPlus40) {
-                  tick = appStore.currentTick + 40;
-                }
-                if (targetTickType == TargetTickType.autoCurrentPlus60) {
-                  tick = appStore.currentTick + 60;
-                }
-              }
-              return Center(
-                  child: Padding(
-                      padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
-                      child: RichText(
-                          text: TextSpan(children: [
-                        TextSpan(
-                            text: tick.asThousands(),
-                            style: TextStyles.inputBoxNormalStyle),
-                        TextSpan(
-                            text:
-                                " ${l10n.sendItemLabelCurrentTick(frozenCurrentTick?.asThousands() ?? appStore.currentTick.asThousands())}",
-                            style: TextStyles.inputBoxSmallStyle)
-                      ]))));
-            }))
-          ]);
-    }
-    return Container();
-  }
-
   Widget getAdvancedOptions() {
     final l10n = l10nOf(context);
 
@@ -416,17 +321,16 @@ class _SendState extends State<Send> {
                   dropdownMenuTheme: DropdownMenuThemeData(
                     textStyle: TextStyles.inputBoxNormalStyle,
                   )),
-              child: ThemedControls.dropdown<TargetTickType>(
+              child: ThemedControls.dropdown<TargetTickTypeEnum>(
                 items: getTickList(),
-                onChanged: (TargetTickType? value) {
+                onChanged: (TargetTickTypeEnum? value) {
                   setState(() {
                     targetTickType = value!;
                   });
                 },
                 value: targetTickType,
               )),
-          Column(children: getOverrideTick()),
-          getAutoTick(),
+          Column(children: getOverrideTick())
         ]);
   }
 
@@ -562,6 +466,12 @@ class _SendState extends State<Send> {
                       ),
                       FormBuilderTextField(
                         //decoration: const InputDecoration(labelText: 'Amount'),
+                        keyboardType: const TextInputType.numberWithOptions(
+                          decimal:
+                              false, // Set to true if you want to allow decimal numbers
+                          signed:
+                              false, // Set to true if you want to allow signed numbers
+                        ),
                         decoration: ThemeInputDecorations.normalInputbox
                             .copyWith(hintMaxLines: 1),
                         name: l10n.accountSendLabelAmount,
@@ -675,6 +585,8 @@ class _SendState extends State<Send> {
   }
 
   void transferNowHandler() async {
+    final l10n = l10nOf(context);
+
     _formKey.currentState?.validate();
     if (!_formKey.currentState!.isValid) {
       return;
@@ -685,25 +597,22 @@ class _SendState extends State<Send> {
       return;
     }
 
-    //Make sure that current tick is not in the past
-
     setState(() {
       isLoading = true;
-
-      frozenCurrentTick = appStore.currentTick;
-      if (targetTickType == TargetTickType.manual) {
-        frozenTargetTick = int.tryParse(tickController.text);
-      } else if (targetTickType == TargetTickType.autoCurrentPlus20) {
-        frozenTargetTick = frozenCurrentTick! + 20;
-      } else if (targetTickType == TargetTickType.autoCurrentPlus40) {
-        frozenTargetTick = frozenCurrentTick! + 40;
-      } else if (targetTickType == TargetTickType.autoCurrentPlus60) {
-        frozenTargetTick = frozenCurrentTick! + 60;
-      }
     });
 
+    int? targetTick;
+
+    if (targetTickType == TargetTickTypeEnum.manual) {
+      targetTick = int.tryParse(tickController.text);
+    } else {
+      // fetch latest tick
+      int latestTick = await apiService.getCurrentTick();
+      targetTick = latestTick + targetTickType.value;
+    }
+
     bool result = await sendTransactionDialog(context, widget.item.publicId,
-        destinationID.text, getQubicAmount(), frozenTargetTick!);
+        destinationID.text, getQubicAmount(), targetTick!);
     if (!result) {
       setState(() {
         isLoading = false;
@@ -715,20 +624,13 @@ class _SendState extends State<Send> {
     //Clear the state
     setState(() {
       isLoading = false;
-      frozenCurrentTick = null;
-      frozenTargetTick = null;
       getIt.get<PersistentTabController>().jumpToTab(1);
     });
 
     Navigator.pop(context);
-    //Timer(const Duration(seconds: 1), () => Navigator.pop(context));
 
-    final l10n = l10nOf(context);
-    _globalSnackBar.show(l10n.generalSnackBarMessageTransactionSubmitted);
-
-    setState(() {
-      isLoading = false;
-    });
+    _globalSnackBar.show(l10n
+        .generalSnackBarMessageTransactionSubmitted(targetTick!.asThousands()));
   }
 
   TextEditingController destinationID = TextEditingController();

--- a/lib/pages/main/wallet_contents/transfer_asset.dart
+++ b/lib/pages/main/wallet_contents/transfer_asset.dart
@@ -17,6 +17,7 @@ import 'package:qubic_wallet/helpers/re_auth_dialog.dart';
 import 'package:qubic_wallet/helpers/sendTransaction.dart';
 import 'package:qubic_wallet/helpers/global_snack_bar.dart';
 import 'package:qubic_wallet/models/qubic_list_vm.dart';
+import 'package:qubic_wallet/resources/qubic_li.dart';
 import 'package:qubic_wallet/stores/application_store.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:intl/intl.dart';
@@ -26,17 +27,7 @@ import 'package:qubic_wallet/styles/text_styles.dart';
 import 'package:qubic_wallet/styles/themed_controls.dart';
 import 'package:qubic_wallet/timed_controller.dart';
 import 'package:qubic_wallet/l10n/l10n.dart';
-
-enum TargetTickType {
-  autoCurrentPlus20,
-  autoCurrentPlus40,
-  autoCurrentPlus60,
-  manual
-}
-
-const int autoCurrentPlus20Value = 20;
-const int autoCurrentPlus40Value = 40;
-const int autoCurrentPlus60Value = 60;
+import 'package:qubic_wallet/helpers/target_tick.dart';
 
 class TransferAsset extends StatefulWidget {
   final QubicListVm item;
@@ -51,14 +42,12 @@ class TransferAsset extends StatefulWidget {
 class _TransferAssetState extends State<TransferAsset> {
   final _formKey = GlobalKey<FormBuilderState>();
   final ApplicationStore appStore = getIt<ApplicationStore>();
+  final QubicLi apiService = getIt<QubicLi>();
   final TimedController _timedController = getIt<TimedController>();
   final GlobalKey<_TransferAssetState> widgetKey = GlobalKey();
   final GlobalSnackBar _globalSnackBar = getIt<GlobalSnackBar>();
-  int targetTick = 0;
-  int? frozenTargetTick;
-  int? frozenCurrentTick;
   String? transferError;
-  TargetTickType targetTickType = TargetTickType.autoCurrentPlus20;
+  TargetTickTypeEnum targetTickType = defaultTargetTickType;
 
   final NumberFormat formatter = NumberFormat.decimalPatternDigits(
     locale: 'en_us',
@@ -66,25 +55,21 @@ class _TransferAssetState extends State<TransferAsset> {
   );
 
   List<bool> expanded = [false];
-  List<DropdownMenuItem<TargetTickType>> getTickList() {
+
+  List<DropdownMenuItem<TargetTickTypeEnum>> getTickList() {
     final l10n = l10nOf(context);
-    return [
-      DropdownMenuItem(
-          value: TargetTickType.autoCurrentPlus20,
-          child: Text(
-              l10n.sendItemLabelTargetTickAutomatic(autoCurrentPlus20Value))),
-      DropdownMenuItem(
-          value: TargetTickType.autoCurrentPlus40,
-          child: Text(
-              l10n.sendItemLabelTargetTickAutomatic(autoCurrentPlus40Value))),
-      DropdownMenuItem(
-          value: TargetTickType.autoCurrentPlus60,
-          child: Text(
-              l10n.sendItemLabelTargetTickAutomatic(autoCurrentPlus60Value))),
-      DropdownMenuItem(
-          value: TargetTickType.manual,
-          child: Text(l10n.sendItemLabelTargetTickManual))
-    ];
+
+    return TargetTickTypeEnum.values.map((targetTickType) {
+      return DropdownMenuItem<TargetTickTypeEnum>(
+        value: targetTickType,
+        child: Text(
+            targetTickType == TargetTickTypeEnum.manual
+                ? l10n.sendItemLabelTargetTickManual
+                : l10n.sendItemLabelTargetTickAutomatic(targetTickType.value),
+            style: TextStyles
+                .inputBoxSmallStyle), // Display name without enum prefix
+      );
+    }).toList();
   }
 
   String? generatedPublicId;
@@ -278,33 +263,10 @@ class _TransferAssetState extends State<TransferAsset> {
         });
   }
 
-  Widget getAdvancedRadio(TargetTickType type, String label) {
-    return InkWell(
-        onTap: () {
-          setState(() {
-            targetTickType = type;
-          });
-        },
-        child: Ink(
-            child: ListTile(
-                dense: true,
-                minVerticalPadding: ThemePaddings.miniPadding,
-                subtitle: Row(children: [
-                  Radio<TargetTickType>(
-                      value: type,
-                      groupValue: targetTickType,
-                      onChanged: (TargetTickType? value) {
-                        setState(() {
-                          targetTickType = value ?? type;
-                        });
-                      }),
-                  Text(label)
-                ]))));
-  }
-
   List<Widget> getOverrideTick() {
     final l10n = l10nOf(context);
-    if ((targetTickType == TargetTickType.manual) && (expanded[0] == true)) {
+    if ((targetTickType == TargetTickTypeEnum.manual) &&
+        (expanded[0] == true)) {
       return [
         ThemedControls.spacerVerticalSmall(),
         Row(
@@ -320,10 +282,7 @@ class _TransferAssetState extends State<TransferAsset> {
                       appStore.currentTick.asThousands()),
                   style: TextStyles.transparentButtonTextSmall);
             }), onPressed: () {
-              if (widget.item.amount == null) {
-                return;
-              }
-              if (widget.item.amount! > 0) {
+              if (appStore.currentTick > 0) {
                 tickController.text = appStore.currentTick.toString();
               }
             }),
@@ -349,53 +308,6 @@ class _TransferAssetState extends State<TransferAsset> {
     return [Container()];
   }
 
-  Widget getAutoTick() {
-    final l10n = l10nOf(context);
-    if (targetTickType != TargetTickType.manual) {
-      return Column(
-          mainAxisSize: MainAxisSize.max,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            ThemedControls.spacerVerticalNormal(),
-            ThemedControls.spacerVerticalNormal(),
-            Text(l10n.sendItemLabelTargetTick,
-                style: TextStyles.labelTextNormal),
-            ThemedControls.spacerVerticalMini(),
-            ThemedControls.inputboxlikeLabel(
-                child: Observer(builder: (context) {
-              int tick = 0;
-              if (frozenTargetTick != null) {
-                tick = frozenTargetTick!;
-              } else {
-                if (targetTickType == TargetTickType.autoCurrentPlus20) {
-                  tick = appStore.currentTick + autoCurrentPlus20Value;
-                }
-                if (targetTickType == TargetTickType.autoCurrentPlus40) {
-                  tick = appStore.currentTick + autoCurrentPlus40Value;
-                }
-                if (targetTickType == TargetTickType.autoCurrentPlus60) {
-                  tick = appStore.currentTick + autoCurrentPlus60Value;
-                }
-              }
-              return Padding(
-                  padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
-                  child: RichText(
-                      text: TextSpan(children: [
-                    TextSpan(
-                        text: tick.asThousands(),
-                        style: TextStyles.inputBoxNormalStyle),
-                    TextSpan(
-                        text:
-                            " ${l10n.sendItemLabelCurrentTick(frozenCurrentTick?.asThousands() ?? appStore.currentTick.asThousands())}",
-                        style: TextStyles.inputBoxSmallStyle)
-                  ])));
-            }))
-          ]);
-    }
-    return Container();
-  }
-
   Widget getAdvancedOptions() {
     final l10n = l10nOf(context);
     return Column(
@@ -406,17 +318,16 @@ class _TransferAssetState extends State<TransferAsset> {
           Text(l10n.sendItemLabelDetermineTargetTick,
               style: TextStyles.labelTextNormal),
           ThemedControls.spacerVerticalMini(),
-          ThemedControls.dropdown<TargetTickType>(
+          ThemedControls.dropdown<TargetTickTypeEnum>(
               value: targetTickType,
-              onChanged: (TargetTickType? value) {
+              onChanged: (TargetTickTypeEnum? value) {
                 // This is called when the user selects an item.
                 setState(() {
                   targetTickType = value!;
                 });
               },
               items: getTickList()),
-          Column(children: getOverrideTick()),
-          getAutoTick(),
+          Column(children: getOverrideTick())
         ]);
   }
 
@@ -514,7 +425,10 @@ class _TransferAssetState extends State<TransferAsset> {
       controller: numberOfSharesCtrl,
       enableSuggestions: false,
       textAlign: TextAlign.end,
-      keyboardType: TextInputType.number,
+      keyboardType: const TextInputType.numberWithOptions(
+        decimal: false, // Set to true if you want to allow decimal numbers
+        signed: false, // Set to true if you want to allow signed numbers
+      ),
       validator: FormBuilderValidators.compose([
         FormBuilderValidators.required(
             errorText: l10n.generalErrorRequiredField),
@@ -731,22 +645,19 @@ class _TransferAssetState extends State<TransferAsset> {
       return;
     }
 
-    //Make sure that current tick is not in the past
-
     setState(() {
       isLoading = true;
-
-      frozenCurrentTick = appStore.currentTick;
-      if (targetTickType == TargetTickType.manual) {
-        frozenTargetTick = int.tryParse(tickController.text);
-      } else if (targetTickType == TargetTickType.autoCurrentPlus20) {
-        frozenTargetTick = frozenCurrentTick! + 20;
-      } else if (targetTickType == TargetTickType.autoCurrentPlus40) {
-        frozenTargetTick = frozenCurrentTick! + 40;
-      } else if (targetTickType == TargetTickType.autoCurrentPlus60) {
-        frozenTargetTick = frozenCurrentTick! + 60;
-      }
     });
+
+    int? targetTick;
+
+    if (targetTickType == TargetTickTypeEnum.manual) {
+      targetTick = int.tryParse(tickController.text);
+    } else {
+      // fetch latest tick
+      int latestTick = await apiService.getCurrentTick();
+      targetTick = latestTick + targetTickType.value;
+    }
 
     bool result = await sendAssetTransferTransactionDialog(
         context,
@@ -755,7 +666,7 @@ class _TransferAssetState extends State<TransferAsset> {
         widget.asset.assetName,
         widget.asset.issuerIdentity,
         getAssetAmount(),
-        frozenTargetTick!);
+        targetTick!);
 
     if (!result) {
       setState(() {
@@ -768,18 +679,13 @@ class _TransferAssetState extends State<TransferAsset> {
     //Clear the state
     setState(() {
       isLoading = false;
-      frozenCurrentTick = null;
-      frozenTargetTick = null;
       getIt.get<PersistentTabController>().jumpToTab(1);
     });
 
     Navigator.pop(context);
-    //Timer(const Duration(seconds: 1), () => Navigator.pop(context));
-    _globalSnackBar.show(l10n.generalSnackBarMessageTransactionSubmitted);
 
-    setState(() {
-      isLoading = false;
-    });
+    _globalSnackBar.show(l10n
+        .generalSnackBarMessageTransactionSubmitted(targetTick!.asThousands()));
   }
 
   TextEditingController destinationID = TextEditingController();


### PR DESCRIPTION
+5 as default target tick for transactions. This is a temporary solution. The idea is in the future we can get the + number of ticks suggestion from the server based on the duration of the previous ticks. I'll open a ticket for integration to provide this.
Hide tick label when choosing automatic target tick. 
Fetch current tick before to submit the transaction. 
Update submit trx snackbar message to include the tick number in the message (same message used in web wallet, translations taken from there)
Enum created for automatic target tick options (5, 10, 20, 40).
Resend trx: target tick removed from the alert and assign the value with the default target tick type, also minor styling fixes.