### PR TITLE
Feature/pause fetch timers on inactive

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -25,6 +25,7 @@ abstract class Config {
 
   static const fetchEverySeconds = 60;
   static const fetchEverySecondsSlow = 60 * 5;
+  static const inactiveSecondsLimit = 120;
 
   static const checkForTamperedUtils = true;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,9 +18,8 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 Future<void> main() async {
   DArgon2Flutter.init(); //Initialize DArgon 2
-  setupDI(); //Dependency injection
-
   WidgetsFlutterBinding.ensureInitialized();
+  setupDI(); //Dependency injection
   SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
   SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
     statusBarColor: Colors.transparent,

--- a/lib/pages/auth/sign_in.dart
+++ b/lib/pages/auth/sign_in.dart
@@ -336,7 +336,7 @@ class _SignInState extends State<SignIn>
                         await _settingsStore.loadSettings();
                         _appStore.checkWalletIsInitialized();
                         _appStore.signOut();
-                        _timedController.stopFetchTimer();
+                        _timedController.stopFetchTimers();
                         Navigator.pop(context);
                         _globalSnackbar
                             .show(l10n.generalSnackBarMessageWalletDataErased);

--- a/lib/pages/main/main_screen.dart
+++ b/lib/pages/main/main_screen.dart
@@ -181,7 +181,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
   @override
   void dispose() {
-    _timedController.stopFetchTimer();
+    _timedController.stopFetchTimers();
     _disposeSnackbarAuto();
 
     WidgetsBinding.instance.removeObserver(this);

--- a/lib/pages/main/tab_settings.dart
+++ b/lib/pages/main/tab_settings.dart
@@ -199,7 +199,7 @@ class _TabSettingsState extends State<TabSettings> {
                       0); // so after unlock, it goes to Home
                   appStore.signOut();
                   appStore.checkWalletIsInitialized();
-                  timedController.stopFetchTimer();
+                  timedController.stopFetchTimers();
                   context.go('/signInNoAuth');
                 },
               ),
@@ -226,7 +226,7 @@ class _TabSettingsState extends State<TabSettings> {
                           await settingsStore.loadSettings();
                           appStore.checkWalletIsInitialized();
                           appStore.signOut();
-                          timedController.stopFetchTimer();
+                          timedController.stopFetchTimers();
                           Navigator.pop(context);
                           context.go("/signInNoAuth");
                           _globalSnackBar.show(


### PR DESCRIPTION
This pull request updates timer management to handle app inactivity better:

- Added a 120-second inactivity threshold (inactiveSecondsLimit) to pause both _fetchTimer an _fetchTimerSlow when the app goes to the background.
- Ensured that timers are restarted when the app resumes.
- Ensured that _fetchTimerSlow is closed when wallet is locked.

Fixes #60.