### PR TITLE
Fix for opening the web explorer for a transaction id

### DIFF
--- a/lib/pages/main/wallet_contents/explorer/explorer_result_page.dart
+++ b/lib/pages/main/wallet_contents/explorer/explorer_result_page.dart
@@ -225,9 +225,10 @@ class _ExplorerResultPageState extends State<ExplorerResultPage> {
             // it's displaying all the transactions in the tick
             explorerUrl += "/network/tick/$tick";
 
-          if (await canLaunchUrlString(explorerUrl)) {
-            await launchUrlString(explorerUrl,
-                mode: LaunchMode.externalApplication);
+            if (await canLaunchUrlString(explorerUrl)) {
+              await launchUrlString(explorerUrl,
+                  mode: LaunchMode.externalApplication);
+            }
           }
         },
       ),

--- a/lib/pages/main/wallet_contents/explorer/explorer_result_page.dart
+++ b/lib/pages/main/wallet_contents/explorer/explorer_result_page.dart
@@ -218,12 +218,12 @@ class _ExplorerResultPageState extends State<ExplorerResultPage> {
 
           if (widget.resultType == ExplorerResultType.publicId) {
             explorerUrl += "/network/address/$qubicId";
-          } else if (widget.resultType == ExplorerResultType.tick) {
-            explorerUrl += "/network/tick/$tick";
-          } else {
-            // if transaction type
+          } else if (focusedTransactionHash != null) {
+            // if showing only one transaction
             explorerUrl += "/network/tx/$focusedTransactionHash";
-          }
+          } else {
+            // it's displaying all the transactions in the tick
+            explorerUrl += "/network/tick/$tick";
 
           if (await canLaunchUrlString(explorerUrl)) {
             await launchUrlString(explorerUrl,


### PR DESCRIPTION
Fix for opening the web explorer for a transaction id when it's viewing the flutter explorer trx focus only