### PR TITLE
Fix timers not stopping after inactiveSecondsLimit

### DIFF
--- a/lib/pages/main/main_screen.dart
+++ b/lib/pages/main/main_screen.dart
@@ -97,9 +97,6 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
         backgroundColor: Colors.transparent,
       );
     }
-
-    _timedController.setupFetchTimer(true);
-    _timedController.setupSlowTimer(true);
     _controller = PersistentTabController(initialIndex: widget.initialTabIndex);
     // _controller.jumpToTab(value);
     _controller.addListener(() {


### PR DESCRIPTION
This PR resolves an issue where timers continued to run after the inactiveSecondsLimit. The duplicate timer setup in the MainScreen has been removed, ensuring timers are only initialized once when the app is resumed, preventing unnecessary multiple timer instances. 


Fixes #60 