### PR TITLE
Bump up the version for qubic helper files to 3.0.8

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -40,20 +40,20 @@ abstract class Config {
   //Qubic Helper Utilities
   static final qubicHelper = QubicHelperConfig(
       win64: QubicHelperConfigEntry(
-          filename: "qubic-helper-win-x64-3_0_6.exe",
+          filename: "qubic-helper-win-x64-3_0_8.exe",
           downloadPath:
-              "https://github.com/qubic/ts-library-wrapper/releases/download/3.0.6/qubic-helper-win-x64-3_0_6.exe",
-          checksum: "55236d3b6d5d7c795807cbf89f77423d"),
+              "https://github.com/qubic/ts-library-wrapper/releases/download/3.0.8/qubic-helper-win-x64-3_0_8.exe",
+          checksum: "25a673010749a2c1cbbf97d023b02b1b"),
       linux64: QubicHelperConfigEntry(
-          filename: "qubic-helper-linux-x64-3_0_6",
+          filename: "qubic-helper-linux-x64-3_0_8",
           downloadPath:
-              "https://github.com/qubic/ts-library-wrapper/releases/download/3.0.6/qubic-helper-linux-x64-3_0_6",
-          checksum: "503a87fadc425692b7d0d0579f56683e"),
+              "https://github.com/qubic/ts-library-wrapper/releases/download/3.0.8/qubic-helper-linux-x64-3_0_8",
+          checksum: "43a6f19eea3289ed53b45987305e06f0"),
       macOs64: QubicHelperConfigEntry(
-          filename: "qubic-helper-mac-x64-3_0_6",
+          filename: "qubic-helper-mac-x64-3_0_8",
           downloadPath:
-              "https://github.com/qubic/ts-library-wrapper/releases/download/3.0.6/qubic-helper-mac-x64-3_0_6",
-          checksum: "45588af4b72234858dca3e1094f2aaeb"));
+              "https://github.com/qubic/ts-library-wrapper/releases/download/3.0.8/qubic-helper-mac-x64-3_0_8",
+          checksum: "8166782f742251d486309f0007d96a59"));
 
   // This will only be read in Debug mode. In Release mode, proxy setup is ignored.
   static const bool useProxy = false; // Can be set to `true` to use a proxy


### PR DESCRIPTION
This version includes helper functions for validating watch-only accounts and exporting vault files that contain watch-only accounts for desktop platforms.