### PR TITLE
Bugfix/optimize explorer page scrolling

### DIFF
--- a/lib/components/explorer_result_page_qubic_id/explorer_result_page_qubic_id.dart
+++ b/lib/components/explorer_result_page_qubic_id/explorer_result_page_qubic_id.dart
@@ -17,19 +17,16 @@ class ExplorerResultPageQubicId extends StatelessWidget {
   final ExplorerIdInfoDto idInfo;
 
   Widget listTransactions() {
-    return Column(
-      mainAxisSize: MainAxisSize.max,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        for (var transaction in idInfo.latestTransfers!)
-          Padding(
+    return SliverList.builder(
+        itemCount: idInfo.latestTransfers!.length,
+        itemBuilder: (context, index) {
+          final transaction = idInfo.latestTransfers![index];
+          return Padding(
             padding: const EdgeInsets.only(bottom: ThemePaddings.normalPadding),
             child: ExplorerResultPageTransactionItem(
                 transaction: transaction, isFocused: false, showTick: true),
-          ),
-        const SizedBox(height: ThemePaddings.normalPadding)
-      ],
-    );
+          );
+        });
   }
 
   Widget getTransactionsHeader(BuildContext context) {
@@ -45,17 +42,16 @@ class ExplorerResultPageQubicId extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        ExplorerResultPageQubicIdHeader(
-          idInfo: idInfo,
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+          child: ExplorerResultPageQubicIdHeader(idInfo: idInfo),
         ),
-        getTransactionsHeader(context),
-        idInfo.latestTransfers != null && idInfo.latestTransfers!.isNotEmpty
-            ? listTransactions()
-            : Container(),
-        ThemedControls.spacerVerticalSmall(),
+        SliverToBoxAdapter(child: getTransactionsHeader(context)),
+        if (idInfo.latestTransfers != null &&
+            idInfo.latestTransfers!.isNotEmpty)
+          listTransactions(),
+        SliverToBoxAdapter(child: ThemedControls.spacerVerticalSmall()),
       ],
     );
   }

--- a/lib/components/explorer_result_page_tick/explorer_result_page_tick.dart
+++ b/lib/components/explorer_result_page_tick/explorer_result_page_tick.dart
@@ -108,17 +108,6 @@ class ExplorerResultPageTick extends StatelessWidget {
         ),
         if (tickInfo.transactions != null && tickInfo.transactions!.isNotEmpty)
           listTransactions(),
-        // Padding(
-        //     padding: EdgeInsets.only(
-        //         left: ThemeEdgeInsets.pageInsets.left,
-        //         right: ThemeEdgeInsets.pageInsets.right),
-        //     child:
-        //         Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-        //       getTransactionsHeader(context),
-        //       tickInfo.transactions != null && tickInfo.transactions!.isNotEmpty
-        //           ? listTransactions()
-        //           : Container()
-        //     ])),
       ],
     );
   }

--- a/lib/components/explorer_result_page_tick/explorer_result_page_tick.dart
+++ b/lib/components/explorer_result_page_tick/explorer_result_page_tick.dart
@@ -25,27 +25,25 @@ class ExplorerResultPageTick extends StatelessWidget {
       onRequestViewChange;
 
   Widget listTransactions() {
-    return Column(
-      mainAxisSize: MainAxisSize.max,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        ThemedControls.spacerVerticalNormal(),
-        for (var transaction in tickInfo.transactions!)
-          focusedTransactionId == null ||
-                  focusedTransactionId! == transaction.id
-              ? Padding(
-                  padding: const EdgeInsets.only(
-                      bottom: ThemePaddings.normalPadding),
-                  child: ExplorerResultPageTransactionItem(
-                    transaction: transaction,
-                    isFocused: focusedTransactionId == null
-                        ? false
-                        : focusedTransactionId! == transaction.id,
-                    dataStatus: tickInfo.completed,
-                  ),
-                )
-              : Container()
-      ],
+    return SliverList.builder(
+      itemBuilder: (context, index) {
+        final transaction = tickInfo.transactions![index];
+        return focusedTransactionId == null ||
+                focusedTransactionId! == transaction.id
+            ? Padding(
+                padding:
+                    const EdgeInsets.only(bottom: ThemePaddings.normalPadding),
+                child: ExplorerResultPageTransactionItem(
+                  transaction: transaction,
+                  isFocused: focusedTransactionId == null
+                      ? false
+                      : focusedTransactionId! == transaction.id,
+                  dataStatus: tickInfo.completed,
+                ),
+              )
+            : const SizedBox.shrink();
+      },
+      itemCount: tickInfo.transactions!.length,
     );
   }
 
@@ -88,28 +86,39 @@ class ExplorerResultPageTick extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        ExplorerResultPageTickHeader(
-            tickInfo: tickInfo,
-            onTickChange: onRequestViewChange != null
-                ? (tick) => {
-                      onRequestViewChange!(
-                          RequestViewChangeType.tick, tick, null)
-                    }
-                : null),
-        Padding(
-            padding: EdgeInsets.only(
-                left: ThemeEdgeInsets.pageInsets.left,
-                right: ThemeEdgeInsets.pageInsets.right),
-            child:
-                Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-              getTransactionsHeader(context),
-              tickInfo.transactions != null && tickInfo.transactions!.isNotEmpty
-                  ? listTransactions()
-                  : Container()
-            ])),
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+          child: ExplorerResultPageTickHeader(
+              tickInfo: tickInfo,
+              onTickChange: onRequestViewChange != null
+                  ? (tick) => {
+                        onRequestViewChange!(
+                            RequestViewChangeType.tick, tick, null)
+                      }
+                  : null),
+        ),
+        SliverPadding(
+          padding: EdgeInsets.only(
+              left: ThemeEdgeInsets.pageInsets.left,
+              right: ThemeEdgeInsets.pageInsets.right),
+          sliver: SliverToBoxAdapter(
+            child: getTransactionsHeader(context),
+          ),
+        ),
+        if (tickInfo.transactions != null && tickInfo.transactions!.isNotEmpty)
+          listTransactions(),
+        // Padding(
+        //     padding: EdgeInsets.only(
+        //         left: ThemeEdgeInsets.pageInsets.left,
+        //         right: ThemeEdgeInsets.pageInsets.right),
+        //     child:
+        //         Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+        //       getTransactionsHeader(context),
+        //       tickInfo.transactions != null && tickInfo.transactions!.isNotEmpty
+        //           ? listTransactions()
+        //           : Container()
+        //     ])),
       ],
     );
   }

--- a/lib/pages/main/wallet_contents/explorer/explorer_result_page.dart
+++ b/lib/pages/main/wallet_contents/explorer/explorer_result_page.dart
@@ -173,37 +173,29 @@ class _ExplorerResultPageState extends State<ExplorerResultPage> {
   }
 
   Widget getScrollView() {
-    return SingleChildScrollView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        controller: ScrollController(),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            resultType == ExplorerResultType.tick ||
-                    resultType == ExplorerResultType.transaction
-                ? ExplorerResultPageTick(
-                    tickInfo: tickInfo!,
-                    focusedTransactionId: focusedTransactionHash,
-                    onRequestViewChange: (type, tick, publicId) {
-                      if (type == RequestViewChangeType.tick) {
-                        setState(() {
-                          focusedTransactionHash = null;
-                          tickInfo = null;
-                          this.tick = tick;
-                          getInfo();
-                        });
-                      } else if (type == RequestViewChangeType.publicId) {
-                        setState(() {
-                          focusedTransactionHash = null;
-                          tickInfo = null;
-                          qubicId = publicId;
-                          getInfo();
-                        });
-                      }
-                    })
-                : ExplorerResultPageQubicId(idInfo: idInfo!),
-          ],
-        ));
+    return resultType == ExplorerResultType.tick ||
+            resultType == ExplorerResultType.transaction
+        ? ExplorerResultPageTick(
+            tickInfo: tickInfo!,
+            focusedTransactionId: focusedTransactionHash,
+            onRequestViewChange: (type, tick, publicId) {
+              if (type == RequestViewChangeType.tick) {
+                setState(() {
+                  focusedTransactionHash = null;
+                  tickInfo = null;
+                  this.tick = tick;
+                  getInfo();
+                });
+              } else if (type == RequestViewChangeType.publicId) {
+                setState(() {
+                  focusedTransactionHash = null;
+                  tickInfo = null;
+                  qubicId = publicId;
+                  getInfo();
+                });
+              }
+            })
+        : ExplorerResultPageQubicId(idInfo: idInfo!);
   }
 
   List<Widget>? getActions() {


### PR DESCRIPTION
**Changes**
- Replaced SingleChildScrollView and Column with SliverList.builder, which builds items lazily on demand as they are scrolled into view in ExplorerResultPageQubicId and ExplorerResultPageTick.
- Optimized rendering by only building the visible transaction items, reducing the load on the UI and improving performance.

Fixes #134