### PR TITLE
Fix potential memory leak

### DIFF
--- a/lib/pages/auth/sign_in.dart
+++ b/lib/pages/auth/sign_in.dart
@@ -227,7 +227,7 @@ class _SignInState extends State<SignIn>
   Future<void> handleBiometricsAuth() async {
     final l10n = l10nOf(context);
 
-    if (isLoading) {
+    if (isLoading || !mounted) {
       return;
     }
     setState(() {


### PR DESCRIPTION
Got this error now and then

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: setState() called after dispose(): _SignInState#35e1c(lifecycle state: defunct, not mounted)
This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
#0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1167:9)
#1      State.setState (package:flutter/src/widgets/framework.dart:1202:6)
#2      _SignInState.handleBiometricsAuth (package:qubic_wallet/pages/auth/sign_in.dart:268:7)
<asynchronous suspension>
```