### PR TITLE
Disable the use of qubic Cmd in windows / macOS - DO NOT MERGE BEFORE TESTING in MacOS , iOS

### DIFF
--- a/lib/dtos/explorer_transaction_info_dto.dart
+++ b/lib/dtos/explorer_transaction_info_dto.dart
@@ -22,9 +22,9 @@ class ExplorerTransactionInfoDto {
       return ComputedTransactionStatus.success;
     }
     if (executed && !moneyFlew) {
-      return ComputedTransactionStatus.invalid;
+      return ComputedTransactionStatus.failure;
     }
-    return ComputedTransactionStatus.failure;
+    return ComputedTransactionStatus.invalid;
   }
 
   ExplorerTransactionInfoDto(

--- a/lib/pages/auth/import_vault_file.dart
+++ b/lib/pages/auth/import_vault_file.dart
@@ -172,7 +172,9 @@ class _ImportVaultFileState extends State<ImportVaultFile> {
                 }
                 FilePickerResult? result = await FilePicker.platform.pickFiles(
                     dialogTitle: l10n.importVaultFilePickerLabel,
-                    withData: isMobile,
+                    withData: isMobile ||
+                        isWindows ||
+                        isMacOS, //TODO Sally check this in MacOS
                     initialDirectory: directory?.path,
                     //allowedExtensions: ['qubic-vault'],
                     lockParentWindow: true);
@@ -348,11 +350,8 @@ class _ImportVaultFileState extends State<ImportVaultFile> {
         await appStore.checkWalletIsInitialized();
         List<QubicId> ids = [];
         for (var importedSeed in importedSeeds!) {
-          ids.add(QubicId(
-              importedSeed.getSeed(),
-              importedSeed.getPublicId(),
-              importedSeed.getAlias()!,
-              0));
+          ids.add(QubicId(importedSeed.getSeed(), importedSeed.getPublicId(),
+              importedSeed.getAlias()!, 0));
         }
         await appStore.addManyIds(ids);
         await getIt<QubicLi>().authenticate();

--- a/lib/resources/qubic_cmd.dart
+++ b/lib/resources/qubic_cmd.dart
@@ -31,18 +31,21 @@ class QubicCmd {
   void _disposeQubicCMD() {}
 
   void reinitialize() {
-    if ((UniversalPlatform.isAndroid) || (UniversalPlatform.isIOS)) {
+    if ((UniversalPlatform.isAndroid) ||
+        (UniversalPlatform.isIOS) ||
+        (UniversalPlatform.isWindows) ||
+        (UniversalPlatform.isMacOS)) {
       qubicJs.reInitialize();
     }
   }
 
   void dispose() {
-    if ((UniversalPlatform.isAndroid) || (UniversalPlatform.isIOS)) {
-      _disploseQubicJS();
-    }
-    if ((UniversalPlatform.isLinux) ||
+    if ((UniversalPlatform.isAndroid) ||
+        (UniversalPlatform.isIOS) ||
         (UniversalPlatform.isWindows) ||
         (UniversalPlatform.isMacOS)) {
+      _disploseQubicJS();
+    } else if (UniversalPlatform.isLinux) {
       _disposeQubicCMD();
     }
   }

--- a/lib/resources/qubic_cmd.dart
+++ b/lib/resources/qubic_cmd.dart
@@ -13,6 +13,8 @@ class QubicCmd {
   late QubicJs qubicJs;
   late QubicCmdUtils qubicCmdUtils;
 
+  late bool useJs;
+
   Future<void> _initQubicJS() async {
     qubicJs = QubicJs();
     await qubicJs.initialize();
@@ -46,43 +48,42 @@ class QubicCmd {
   }
 
   Future<void> initialize() async {
-    if ((UniversalPlatform.isAndroid) || (UniversalPlatform.isIOS)) {
-      await _initQubicJS();
-    }
-    if ((UniversalPlatform.isLinux) ||
+    if ((UniversalPlatform.isAndroid) ||
+        (UniversalPlatform.isIOS) ||
         (UniversalPlatform.isWindows) ||
         (UniversalPlatform.isMacOS)) {
+      useJs = true;
+    } else if (UniversalPlatform.isDesktop && UniversalPlatform.isLinux) {
+      useJs = false;
+    } else {
+      throw LocalizationManager
+          .instance.appLocalization.generalErrorUnsupportedOS;
+    }
+
+    if (useJs) {
+      await _initQubicJS();
+    } else {
       _initQubicCMD();
     }
   }
 
   Future<String> getPublicIdFromSeed(String seed) async {
-    if ((UniversalPlatform.isAndroid) || (UniversalPlatform.isIOS)) {
+    if (useJs) {
       return await qubicJs.getPublicIdFromSeed(seed);
-    }
-    if ((UniversalPlatform.isLinux) ||
-        (UniversalPlatform.isWindows) ||
-        (UniversalPlatform.isMacOS)) {
+    } else {
       _initQubicCMD();
       return await qubicCmdUtils.getPublicIdFromSeed(seed);
     }
-    throw LocalizationManager
-        .instance.appLocalization.generalErrorUnsupportedOS;
   }
 
   Future<String> createTransaction(
       String seed, String destinationId, int value, int tick) async {
-    if ((UniversalPlatform.isAndroid) || (UniversalPlatform.isIOS)) {
+    if (useJs) {
       return await qubicJs.createTransaction(seed, destinationId, value, tick);
-    }
-    if ((UniversalPlatform.isLinux) ||
-        (UniversalPlatform.isWindows) ||
-        (UniversalPlatform.isMacOS)) {
+    } else {
       return await qubicCmdUtils.createTransaction(
           seed, destinationId, value, tick);
     }
-    throw LocalizationManager
-        .instance.appLocalization.generalErrorUnsupportedOS;
   }
 
   Future<String> createAssetTransferTransaction(
@@ -92,67 +93,45 @@ class QubicCmd {
       String assetIssuer,
       int numberOfAssets,
       int tick) async {
-    if ((UniversalPlatform.isAndroid) || (UniversalPlatform.isIOS)) {
+    if (useJs) {
       return await qubicJs.createAssetTransferTransaction(
           seed, destinationId, assetName, assetIssuer, numberOfAssets, tick);
-    }
-    if ((UniversalPlatform.isLinux) ||
-        (UniversalPlatform.isWindows) ||
-        (UniversalPlatform.isMacOS)) {
+    } else {
       return await qubicCmdUtils.createAssetTransferTransaction(
           seed, destinationId, assetName, assetIssuer, numberOfAssets, tick);
     }
-    throw LocalizationManager
-        .instance.appLocalization.generalErrorUnsupportedOS;
   }
 
   Future<bool> verifyIdentity(String publicId) async {
-    if (UniversalPlatform.isAndroid || UniversalPlatform.isIOS) {
+    if (useJs) {
       return await qubicJs.verifyIdentity(publicId);
-    }
-    if (UniversalPlatform.isLinux ||
-        UniversalPlatform.isWindows ||
-        UniversalPlatform.isMacOS) {
+    } else {
       return await qubicCmdUtils.verifyIdentity(publicId);
     }
-
-    throw Exception(LocalizationManager.instance.appLocalization
-        .generalErrorUnsupportedOS);
   }
 
   Future<Uint8List> createVaultFile(
       String password, List<QubicVaultExportSeed> seeds) async {
-    if ((UniversalPlatform.isAndroid) || (UniversalPlatform.isIOS)) {
+    if (useJs) {
       return await qubicJs.createVaultFile(password, seeds);
-    }
-    if ((UniversalPlatform.isLinux) ||
-        (UniversalPlatform.isWindows) ||
-        (UniversalPlatform.isMacOS)) {
+    } else {
       return await qubicCmdUtils.createVaultFile(password, seeds);
     }
-    throw LocalizationManager
-        .instance.appLocalization.generalErrorUnsupportedOS;
   }
 
   Future<List<QubicImportVaultSeed>> importVaultFile(
       String password, String? filePath, Uint8List? fileContents) async {
-    if ((UniversalPlatform.isAndroid) || (UniversalPlatform.isIOS)) {
+    if (useJs) {
       if (fileContents == null) {
         throw "File contents base64 is required";
       }
       var base64String = base64Encode(fileContents);
       return await qubicJs.importVault(password, base64String);
-    }
-    if ((UniversalPlatform.isLinux) ||
-        (UniversalPlatform.isWindows) ||
-        (UniversalPlatform.isMacOS)) {
+    } else {
       if (filePath == null) {
         throw "File path is required";
       }
       return await qubicCmdUtils.importVaultFile(password, filePath);
     }
-
-    throw LocalizationManager
-        .instance.appLocalization.generalErrorUnsupportedOS;
   }
 }

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -3,16 +3,14 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.security.files.downloads.read-write</key>
+	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array/>
-	<key>com.apple.security.network.client</key>
-	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -3,16 +3,14 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.security.files.downloads.read-write</key>
+	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array/>
-	<key>com.apple.security.network.client</key>
-	<true/>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -274,7 +274,7 @@ packages:
     source: hosted
     version: "3.2.0"
   dargon2_flutter_mobile:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: dargon2_flutter_mobile
       sha256: "22b1b5229371c229cb55ca214262c6cb2189d40f7ef4ab87c1bea75bc2c582bf"


### PR DESCRIPTION
Use the latest version of inappwebview which works on windows and MacOS, this way making qubic-cmd redundant for win, android, macOS, iOS. 
Tested the following: vault import / export , create seed, verify seed, make transaction 

Please refer to this: https://inappwebview.dev/docs/intro#setup-macos for enabling for macOS
