### PR TITLE
Fix wallet connect bugs

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -88,6 +88,5 @@ abstract class Config {
   static const walletConnectRedirectUniversal = "https://wallet.qubic.org";
 
   static const walletConnectChainId = "qubic:main";
-  static const walltConnectChainName = "qubic";
   static const wallectConnectUrlLength = 187;
 }

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -88,5 +88,6 @@ abstract class Config {
   static const walletConnectRedirectUniversal = "https://wallet.qubic.org";
 
   static const walletConnectChainId = "qubic:main";
+  static const walltConnectChainName = "qubic";
   static const wallectConnectUrlLength = 187;
 }

--- a/lib/pages/main/wallet_contents/add_wallet_connect/add_wallet_connect.dart
+++ b/lib/pages/main/wallet_contents/add_wallet_connect/add_wallet_connect.dart
@@ -326,7 +326,6 @@ class _AddWalletConnectState extends State<AddWalletConnect> {
             )
           : _AddWalletConnectDesktopView(
               isLoading: isLoading,
-              pasteAndProceed: pasteAndProceed,
               proceedHandler: proceedHandler,
             ),
     );

--- a/lib/pages/main/wallet_contents/add_wallet_connect/components/add_wallet_connect_desktop_view.dart
+++ b/lib/pages/main/wallet_contents/add_wallet_connect/components/add_wallet_connect_desktop_view.dart
@@ -106,7 +106,7 @@ class _AddWalletConnectDesktopViewState
                 width: double.infinity,
                 height: ButtonStyles.buttonHeight,
                 child: ThemedControls.primaryButtonBigWithChild(
-                    onPressed: canConnect
+                    onPressed: canConnect && !widget.isLoading
                         ? () => widget.proceedHandler(urlController.text)
                         : null,
                     enabled: canConnect,

--- a/lib/pages/main/wallet_contents/add_wallet_connect/components/add_wallet_connect_desktop_view.dart
+++ b/lib/pages/main/wallet_contents/add_wallet_connect/components/add_wallet_connect_desktop_view.dart
@@ -2,12 +2,10 @@ part of '../add_wallet_connect.dart';
 
 class _AddWalletConnectDesktopView extends StatefulWidget {
   final bool isLoading;
-  final VoidCallback pasteAndProceed;
   final Function(String?) proceedHandler;
   const _AddWalletConnectDesktopView({
     super.key,
     required this.isLoading,
-    required this.pasteAndProceed,
     required this.proceedHandler,
   });
 
@@ -108,7 +106,9 @@ class _AddWalletConnectDesktopViewState
                 width: double.infinity,
                 height: ButtonStyles.buttonHeight,
                 child: ThemedControls.primaryButtonBigWithChild(
-                    onPressed: canConnect ? widget.pasteAndProceed : null,
+                    onPressed: canConnect
+                        ? () => widget.proceedHandler(urlController.text)
+                        : null,
                     enabled: canConnect,
                     child: Padding(
                         padding: const EdgeInsets.all(

--- a/lib/pages/main/wallet_contents/add_wallet_connect/components/add_wallet_connect_desktop_view.dart
+++ b/lib/pages/main/wallet_contents/add_wallet_connect/components/add_wallet_connect_desktop_view.dart
@@ -57,61 +57,6 @@ class _AddWalletConnectDesktopViewState
                             child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: <Widget>[
-                            if (isMobile) ...[
-                              ClipRRect(
-                                borderRadius: BorderRadius.circular(12),
-                                child: Container(
-                                  decoration: BoxDecoration(
-                                    borderRadius: BorderRadius.circular(12),
-                                    border: Border.all(
-                                        color:
-                                            LightThemeColors.inputBorderColor,
-                                        width: 1),
-                                  ),
-                                  width: double.infinity,
-                                  height: 280,
-                                  child: CustomPaint(
-                                    foregroundPainter: ScannerCornerBorders(),
-                                    child: ClipRRect(
-                                      borderRadius: BorderRadius.circular(12),
-                                      child: MobileScanner(
-                                        fit: BoxFit.cover,
-                                        controller: MobileScannerController(
-                                          detectionSpeed:
-                                              DetectionSpeed.noDuplicates,
-                                          facing: CameraFacing.back,
-                                          torchEnabled: false,
-                                        ),
-                                        onDetect: (capture) {
-                                          final List<Barcode> barcodes =
-                                              capture.barcodes;
-                                          for (final barcode in barcodes) {
-                                            if (barcode.rawValue != null &&
-                                                !widget.isLoading) {
-                                              _globalSnackBar.show(l10n
-                                                  .generalSnackBarMessageQRScannedWithSuccess);
-                                              widget.proceedHandler(
-                                                  barcode.rawValue);
-                                            }
-                                          }
-                                        },
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                              ThemedControls.spacerVerticalBig(),
-                              Padding(
-                                padding: const EdgeInsets.symmetric(
-                                    horizontal: ThemePaddings.normalPadding),
-                                child: Text(
-                                  l10n.wcPointCameraToQR,
-                                  textAlign: TextAlign.center,
-                                  style: TextStyles.labelTextNormal
-                                      .copyWith(fontWeight: FontWeight.w400),
-                                ),
-                              )
-                            ],
                             ThemedControls.pageHeader(
                               headerText: l10n.wcAddWcTitle,
                             ),

--- a/lib/pages/main/wallet_contents/add_wallet_connect/components/add_wallet_connect_mobile_view.dart
+++ b/lib/pages/main/wallet_contents/add_wallet_connect/components/add_wallet_connect_mobile_view.dart
@@ -117,7 +117,7 @@ class _AddWalletConnectMobileViewState
                 width: double.infinity,
                 height: ButtonStyles.buttonHeight,
                 child: ThemedControls.secondaryButtonWithChild(
-                    onPressed: widget.pasteAndProceed,
+                    onPressed: widget.isLoading ? null : widget.pasteAndProceed,
                     child: Padding(
                         padding: const EdgeInsets.all(
                             ThemePaddings.smallPadding + 3),

--- a/lib/pages/main/wallet_contents/settings/wallet_connect/wallet_connect.dart
+++ b/lib/pages/main/wallet_contents/settings/wallet_connect/wallet_connect.dart
@@ -25,10 +25,10 @@ class WalletConnectSettings extends StatefulWidget {
 
   @override
   // ignore: library_private_types_in_public_api
-  _AboutWalletState createState() => _AboutWalletState();
+  _WalletConnectSettingsState createState() => _WalletConnectSettingsState();
 }
 
-class _AboutWalletState extends State<WalletConnectSettings> {
+class _WalletConnectSettingsState extends State<WalletConnectSettings> {
   final WalletConnectService walletConnectService =
       getIt<WalletConnectService>();
 

--- a/lib/pages/main/wallet_contents/settings/wallet_connect/wallet_connect.dart
+++ b/lib/pages/main/wallet_contents/settings/wallet_connect/wallet_connect.dart
@@ -12,7 +12,6 @@ import 'package:qubic_wallet/l10n/l10n.dart';
 import 'package:qubic_wallet/pages/main/wallet_contents/add_wallet_connect/add_wallet_connect.dart';
 import 'package:qubic_wallet/pages/main/wallet_contents/settings/wallet_connect/components/wallet_connect_expansion_card.dart';
 import 'package:qubic_wallet/services/wallet_connect_service.dart';
-import 'package:qubic_wallet/stores/settings_store.dart';
 import 'package:qubic_wallet/styles/app_icons.dart';
 import 'package:qubic_wallet/styles/button_styles.dart';
 import 'package:qubic_wallet/styles/edge_insets.dart';
@@ -56,16 +55,11 @@ class _AboutWalletState extends State<WalletConnectSettings> {
   }
 
   List<String> getMethods(SessionData sessionData) {
-    if (sessionData.requiredNamespaces == null) {
-      return [];
-    }
-    if (sessionData.requiredNamespaces![Config.walletConnectChainId] == null) {
-      return [];
-    }
-    List<String> localizedStrings = getLocalizedPairingMethods(
-        sessionData.requiredNamespaces?[Config.walletConnectChainId]!.methods ??
-            [],
-        context);
+    List<String> methods =
+        sessionData.namespaces[Config.walltConnectChainName]?.methods ?? [];
+
+    List<String> localizedStrings =
+        getLocalizedPairingMethods(methods, context);
     return localizedStrings;
   }
 

--- a/lib/pages/main/wallet_contents/settings/wallet_connect/wallet_connect.dart
+++ b/lib/pages/main/wallet_contents/settings/wallet_connect/wallet_connect.dart
@@ -19,6 +19,7 @@ import 'package:qubic_wallet/styles/text_styles.dart';
 import 'package:qubic_wallet/styles/themed_controls.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:reown_walletkit/reown_walletkit.dart';
+import 'package:reown_sign/reown_sign.dart';
 
 class WalletConnectSettings extends StatefulWidget {
   const WalletConnectSettings({super.key});
@@ -55,8 +56,11 @@ class _WalletConnectSettingsState extends State<WalletConnectSettings> {
   }
 
   List<String> getMethods(SessionData sessionData) {
-    List<String> methods =
-        sessionData.namespaces[Config.walltConnectChainName]?.methods ?? [];
+    List<String> methods = sessionData
+            .namespaces[NamespaceUtils.getNamespaceFromChain(
+                Config.walletConnectChainId)]
+            ?.methods ??
+        [];
 
     List<String> localizedStrings =
         getLocalizedPairingMethods(methods, context);


### PR DESCRIPTION
**Changes**
- Fix the problem of empty permissions in the WalletConnectSettings screen 
- Remove unused isMobile check from AddWalletConnectDesktopView
- Make the connect button on the desktop validate the TextField text, not the copied text
- Disable the ability to send requests for pairing while the app is loading 
- Rename AboutWalletState to WalletConnectSettingsState to match the widget name