### PR TITLE
Fix to support namespaces where there is a single chainid used as key…

### DIFF
--- a/lib/pages/main/wallet_contents/settings/wallet_connect/wallet_connect.dart
+++ b/lib/pages/main/wallet_contents/settings/wallet_connect/wallet_connect.dart
@@ -56,14 +56,17 @@ class _WalletConnectSettingsState extends State<WalletConnectSettings> {
   }
 
   List<String> getMethods(SessionData sessionData) {
-    List<String> methods = sessionData
-            .namespaces[NamespaceUtils.getNamespaceFromChain(
-                Config.walletConnectChainId)]
-            ?.methods ??
-        [];
+    List<String> methods = NamespaceUtils.getNamespacesMethodsForChainId(
+        chainId:
+            Config.walletConnectChainId, // only chain id supported by the app
+        namespaces: sessionData.namespaces);
 
-    List<String> localizedStrings =
-        getLocalizedPairingMethods(methods, context);
+    List<String> localizedStrings = [];
+
+    if (methods.isNotEmpty) {
+      localizedStrings = getLocalizedPairingMethods(methods, context);
+    }
+
     return localizedStrings;
   }
 


### PR DESCRIPTION
… + namespace in combination with chainid array

Testing data used:

// connects and displays the methods
    const namespaces1 = {
      'qubic': {
        chains: ['qubic:main'],
        methods: [
          'wallet_requestAccounts',
          'qubic_sendQubic',
          'qubic_sendAsset',
          'qubic_signTransaction',
          'qubic_sign'
        ],
        events: ['amountChanged', 'tokenAmountChanged', 'accountsChanged'],
      },
    };

    // connects and displays the methods
    const namespaces2 = {
      'qubic:main': {
        methods: [
          'wallet_requestAccounts',
          'qubic_sendQubic',
          'qubic_sendAsset',
          'qubic_signTransaction',
          'qubic_sign'
        ],
        events: ['amountChanged', 'tokenAmountChanged', 'accountsChanged'],
      }
    };