### PR TITLE
feat: Show pending transactions from appstore until they return from qubic live

### DIFF
--- a/lib/helpers/sendTransaction.dart
+++ b/lib/helpers/sendTransaction.dart
@@ -3,6 +3,7 @@ import 'package:qubic_wallet/di.dart';
 import 'package:qubic_wallet/helpers/platform_helpers.dart';
 import 'package:qubic_wallet/helpers/show_alert_dialog.dart';
 import 'package:qubic_wallet/l10n/l10n.dart';
+import 'package:qubic_wallet/models/transaction_vm.dart';
 import 'package:qubic_wallet/resources/apis/live/qubic_live_api.dart';
 import 'package:qubic_wallet/resources/qubic_cmd.dart';
 import 'package:qubic_wallet/resources/qubic_li.dart';
@@ -80,7 +81,18 @@ Future<bool> sendTransactionDialog(BuildContext context, String sourceId,
 
   //We have the transaction, now let's call the API
   try {
-    await getIt.get<QubicLiveApi>().submitTransaction(transactionKey);
+    final transactionId =
+        await getIt.get<QubicLiveApi>().submitTransaction(transactionKey);
+    final pendingTransaction = TransactionVm(
+        id: transactionId,
+        sourceId: sourceId,
+        destId: destinationId,
+        amount: value,
+        status: ComputedTransactionStatus.pending.name,
+        targetTick: destinationTick,
+        isPending: true,
+        moneyFlow: false);
+    getIt.get<ApplicationStore>().addPendingTransaction(pendingTransaction);
   } catch (e) {
     showAlertDialog(
         context, l10n.sendItemDialogErrorGeneralTitle, e.toString());

--- a/lib/models/transaction_vm.dart
+++ b/lib/models/transaction_vm.dart
@@ -69,22 +69,22 @@ class TransactionVm {
   bool moneyFlow;
 
   TransactionVm(
-      this.id,
-      this.sourceId,
-      this.destId,
-      this.amount,
-      this.status,
+      {required this.id,
+      required this.sourceId,
+      required this.destId,
+      required this.amount,
+      required this.status,
       this.created,
       this.stored,
       this.staged,
       this.broadcasted,
       this.confirmed,
       this.statusUpdate,
-      this.targetTick,
-      this.isPending,
+      required this.targetTick,
+      required this.isPending,
       this.price,
       this.quantity,
-      this.moneyFlow);
+      required this.moneyFlow});
 
   ComputedTransactionStatus getStatus() {
     if (isPending) {
@@ -157,21 +157,21 @@ class TransactionVm {
 
   factory TransactionVm.fromTransactionDto(TransactionDto original) {
     return TransactionVm(
-        original.id,
-        original.sourceId,
-        original.destId,
-        original.amount,
-        original.status,
-        original.created,
-        original.stored,
-        original.staged,
-        original.broadcasted,
-        original.confirmed,
-        original.statusUpdate,
-        original.targetTick,
-        original.isPending,
-        original.price,
-        original.quantity,
-        original.moneyFlow);
+        id: original.id,
+        sourceId: original.sourceId,
+        destId: original.destId,
+        amount: original.amount,
+        status: original.status,
+        created: original.created,
+        stored: original.stored,
+        staged: original.staged,
+        broadcasted: original.broadcasted,
+        confirmed: original.confirmed,
+        statusUpdate: original.statusUpdate,
+        targetTick: original.targetTick,
+        isPending: original.isPending,
+        price: original.price,
+        quantity: original.quantity,
+        moneyFlow: original.moneyFlow);
   }
 }

--- a/lib/resources/apis/live/qubic_live_api.dart
+++ b/lib/resources/apis/live/qubic_live_api.dart
@@ -23,12 +23,12 @@ class QubicLiveApi {
     }
   }
 
-  Future<void> submitTransaction(String transaction) async {
+  Future<String> submitTransaction(String transaction) async {
     try {
       _appStore.incrementPendingRequests();
-      await _dio.post('$_baseUrl${Config.submitTransaction}',
+      final response = await _dio.post('$_baseUrl${Config.submitTransaction}',
           data: {"encodedTransaction": transaction});
-      return;
+      return response.data["transactionId"];
     } catch (error) {
       throw ErrorHandler.handleError(error);
     } finally {

--- a/lib/resources/secure_storage.dart
+++ b/lib/resources/secure_storage.dart
@@ -7,6 +7,7 @@ import 'package:qubic_wallet/models/critical_settings.dart';
 import 'package:qubic_wallet/models/qubic_id.dart';
 import 'package:qubic_wallet/models/qubic_list_vm.dart';
 import 'package:qubic_wallet/models/settings.dart';
+import 'package:qubic_wallet/models/transaction_vm.dart';
 
 class SecureStorageKeys {
   static const prepend = kReleaseMode
@@ -26,6 +27,7 @@ class SecureStorageKeys {
   static const publicIdsList = "${prepend}_PIDs"; // The public IDs
   static const namesList = "${prepend}_NAMEs"; // The names of the IDs
   static const settings = "${prepend}_SETTINGS"; // The settings of the wallet
+  static const pendingTransactions = "${prepend}_PENDING";
 }
 
 class PassAndHash {
@@ -228,9 +230,8 @@ class SecureStorage {
     CriticalSettings settings = await getCriticalSettings();
     List<QubicListVm> list = [];
     for (int i = 0; i < settings.publicIds.length; i++) {
-      list.add(QubicListVm(
-          settings.publicIds[i], settings.names[i], null, null, null,
-          settings.isWatchOnly[i]));
+      list.add(QubicListVm(settings.publicIds[i], settings.names[i], null, null,
+          null, settings.isWatchOnly[i]));
     }
     return list;
   }
@@ -289,7 +290,7 @@ class SecureStorage {
       throw Exception("ID not found");
     }
     return QubicId(settings.privateSeeds[i], settings.publicIds[i],
-          settings.names[i], null);
+        settings.names[i], null);
   }
 
   //Removes a Qubic ID from the secure Storage (Based on its public key)

--- a/lib/stores/application_store.dart
+++ b/lib/stores/application_store.dart
@@ -73,6 +73,9 @@ abstract class _ApplicationStore with Store {
   ObservableList<TransactionVm> currentTransactions =
       ObservableList<TransactionVm>();
 
+  ObservableList<TransactionVm> pendingTransactions =
+      ObservableList<TransactionVm>();
+
   @observable
   TransactionFilter? transactionFilter = TransactionFilter();
 
@@ -89,8 +92,10 @@ abstract class _ApplicationStore with Store {
   @computed
   double get totalAmountsInUSD {
     if (marketInfo == null) return -1;
-    return currentQubicIDs.where((qubic) => !qubic.watchOnly).fold<double>(0,
-        (sum, qubic) => sum + (qubic.amount ?? 0) * marketInfo!.price!.toDouble());
+    return currentQubicIDs.where((qubic) => !qubic.watchOnly).fold<double>(
+        0,
+        (sum, qubic) =>
+            sum + (qubic.amount ?? 0) * marketInfo!.price!.toDouble());
   }
 
   //The market info for $QUBIC
@@ -367,6 +372,14 @@ abstract class _ApplicationStore with Store {
             TransactionVm.fromTransactionDto(transactions[i]);
       }
     }
+    if (pendingTransactions.isNotEmpty) {
+      for (var pendingTrx in pendingTransactions) {
+        if (currentTransactions.any((trx) => trx.id == pendingTrx.id)) {
+          pendingTransactions.remove(pendingTrx);
+        }
+      }
+      currentTransactions.insertAll(0, pendingTransactions);
+    }
   }
 
   int getQubicIDsWithPublicId(String publicId) {
@@ -393,5 +406,10 @@ abstract class _ApplicationStore with Store {
         currentQubicIDs.any(
                 (el) => el.publicId == element.destId.replaceAll(",", "_")) ==
             false);
+  }
+
+  @action
+  addPendingTransaction(TransactionVm transaction) {
+    currentTransactions.add(transaction);
   }
 }

--- a/lib/stores/application_store.g.dart
+++ b/lib/stores/application_store.g.dart
@@ -466,6 +466,17 @@ mixin _$ApplicationStore on _ApplicationStore, Store {
   }
 
   @override
+  dynamic addPendingTransaction(TransactionVm transaction) {
+    final _$actionInfo = _$_ApplicationStoreActionController.startAction(
+        name: '_ApplicationStore.addPendingTransaction');
+    try {
+      return super.addPendingTransaction(transaction);
+    } finally {
+      _$_ApplicationStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
   String toString() {
     return '''
 hasStoredWalletSettings: ${hasStoredWalletSettings},


### PR DESCRIPTION
- [x] Show pending transactions from App store
- [ ] Show rejected transactions from App store after their tick is passed
- [ ] Add local storage to save both types of transactions

Closes #139 