### PR TITLE
fix: Align tick status with label

### DIFF
--- a/lib/components/explorer_result_page_tick/explorer_result_page_tick_header.dart
+++ b/lib/components/explorer_result_page_tick/explorer_result_page_tick_header.dart
@@ -102,7 +102,12 @@ class ExplorerResultPageTickHeader extends StatelessWidget {
                       Text(l10n.explorerTickResultLabelBlockStatus,
                           style: panelHeaderStyle),
                       Text(
-                        " ${tickInfo.completed ? isNotEmpty ? l10n.explorerTickResultLabelBlockStatusNonEmpty : l10n.explorerTickResultLabelBlockStatusEmpty : l10n.explorerTickResultLabelBlockStatusUnknown}",
+                        tickInfo.completed
+                            ? isNotEmpty
+                                ? l10n
+                                    .explorerTickResultLabelBlockStatusNonEmpty
+                                : l10n.explorerTickResultLabelBlockStatusEmpty
+                            : l10n.explorerTickResultLabelBlockStatusUnknown,
                         style: panelHeaderValue.copyWith(
                           color: isNotEmpty
                               ? LightThemeColors.successIncoming


### PR DESCRIPTION
Fixes: #206

Removes the extra space between tick status

![image](https://github.com/user-attachments/assets/995e3c82-786a-489a-86fd-25d71701efa3)

