### PR TITLE
feat: Calrify ReownSignError in Pair screen

### DIFF
--- a/lib/components/wallet_connect/pair.dart
+++ b/lib/components/wallet_connect/pair.dart
@@ -3,17 +3,14 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:qubic_wallet/components/wallet_connect/components/domain_verification_card.dart';
 import 'package:qubic_wallet/di.dart';
 import 'package:qubic_wallet/flutter_flow/theme_paddings.dart';
 import 'package:qubic_wallet/helpers/wallet_connect_methods.dart';
 import 'package:qubic_wallet/l10n/l10n.dart';
-import 'package:qubic_wallet/models/wallet_connect.dart';
 import 'package:qubic_wallet/pages/main/wallet_contents/add_wallet_connect/add_wallet_connect.dart';
 import 'package:qubic_wallet/services/wallet_connect_service.dart';
 import 'package:qubic_wallet/stores/application_store.dart';
-import 'package:qubic_wallet/styles/app_icons.dart';
 import 'package:qubic_wallet/styles/button_styles.dart';
 import 'package:qubic_wallet/styles/edge_insets.dart';
 import 'package:qubic_wallet/styles/text_styles.dart';
@@ -163,6 +160,7 @@ class _PairState extends State<Pair> {
   }
 
   void handleProceed() async {
+    final l10n = l10nOf(context);
     try {
       setState(() {
         isLoading = true;
@@ -178,8 +176,12 @@ class _PairState extends State<Pair> {
     } catch (e) {
       setState(() {
         isLoading = false;
-        wcError = e.toString();
         debugPrint(e.toString());
+        wcError = (e is ReownSignError && e.code == 2)
+            ? l10n.wcErrorProposalExpired
+            : (e is ReownSignError)
+                ? e.message
+                : e.toString();
       });
     }
   }

--- a/lib/components/wallet_connect/pair.dart
+++ b/lib/components/wallet_connect/pair.dart
@@ -177,7 +177,9 @@ class _PairState extends State<Pair> {
       setState(() {
         isLoading = false;
         debugPrint(e.toString());
-        wcError = (e is ReownSignError && e.code == 2)
+        wcError = (e is ReownSignError &&
+                e.code ==
+                    Errors.INTERNAL_ERRORS[Errors.NO_MATCHING_KEY]?["code"])
             ? l10n.wcErrorProposalExpired
             : (e is ReownSignError)
                 ? e.message

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -822,6 +822,7 @@
     "wcErrorUnsupportedNamespaces": "Pair request contains unsupported namespaces",
     "wcErrorUsedURL": "A connection has already been established via this URL",
     "wcErrorPairingTimeout": "Pairing request timed out.",
+    "wcErrorProposalExpired": "The session proposal has expired",
     "wcErrorUnsupportedNetwork": "Unsupported Network",
     "wcErrorUnsupportedNetworkDescription": "This app uses {networkName} network. Currently, Qubic Wallet only supports apps on Qubic Main Network",
     "@wcErrorUnsupportedNetworkDescription": {


### PR DESCRIPTION
This PR ensures a readable message when a ReownSignError happens during the pairing.