### PR TITLE
Bugfix/WalletConnect "Unsupported Network []" When Adding First Account

### DIFF
--- a/lib/pages/main/wallet_contents/add_account.dart
+++ b/lib/pages/main/wallet_contents/add_account.dart
@@ -672,6 +672,7 @@ class _AddAccountState extends State<AddAccount> {
     });
 
     walletConnectService.triggerAccountsChangedEvent();
+    getIt<WalletConnectService>().registerAccount(generatedPublicId!);
 
     if (mounted) {
       Navigator.pop(context);

--- a/lib/services/wallet_connect_service.dart
+++ b/lib/services/wallet_connect_service.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-
 import 'package:qubic_wallet/config.dart';
 import 'package:qubic_wallet/di.dart';
 import 'package:qubic_wallet/dtos/qubic_asset_dto.dart';
@@ -480,8 +479,7 @@ class WalletConnectService {
 
     appStore.currentQubicIDs.forEach(((id) {
       if (id.watchOnly == false) {
-        web3Wallet!.registerAccount(
-            accountAddress: id.publicId, chainId: Config.walletConnectChainId);
+        registerAccount(id.publicId);
       }
     }));
   }
@@ -493,6 +491,15 @@ class WalletConnectService {
       return pairingInfo!;
     } catch (e) {
       rethrow;
+    }
+  }
+
+  void registerAccount(String accountAddress) {
+    if (web3Wallet != null) {
+      web3Wallet!.registerAccount(
+        accountAddress: accountAddress,
+        chainId: Config.walletConnectChainId,
+      );
     }
   }
 


### PR DESCRIPTION
This PR fixes the problem of Fixes a bug where WalletConnect shows an `"unsupported network []"` error if the user creates a new wallet, adds one account, and connects in the same session.
The issue was caused by the account not being registered in `WalletConnectService`.
Now, new accounts are properly registered when added.

