### PR TITLE
fix: highlight delete menu options in red

### DIFF
--- a/lib/components/account_list_item.dart
+++ b/lib/components/account_list_item.dart
@@ -279,7 +279,8 @@ class _AccountListItemState extends State<AccountListItem> {
                   ),
                   PopupMenuItem<CardItem>(
                     value: CardItem.delete,
-                    child: Text(l10n.generalButtonDelete),
+                    child: Text(l10n.generalButtonDelete,
+                        style: const TextStyle(color: LightThemeColors.error)),
                   ),
                 ]));
   }

--- a/lib/components/transaction_item.dart
+++ b/lib/components/transaction_item.dart
@@ -120,7 +120,8 @@ class _TransactionItemState extends State<TransactionItem> {
               if (TransactionActionHelpers.canDelete(widget.item))
                 PopupMenuItem<CardItem>(
                   value: CardItem.delete,
-                  child: Text(l10n.generalButtonDelete),
+                  child: Text(l10n.generalButtonDelete,
+                      style: const TextStyle(color: LightThemeColors.error)),
                 )
             ]);
   }


### PR DESCRIPTION
Apply red color to delete actions in account and transaction popup menus to visually distinguish destructive operations and prevent accidental deletions