### PR TITLE
feat: add platform version constraints for dApps

### DIFF
--- a/lib/dtos/dapp_dto.dart
+++ b/lib/dtos/dapp_dto.dart
@@ -1,4 +1,7 @@
 class DappDto {
+  /// Special value for platformVersions to exclude a platform entirely
+  static const String versionNone = 'none';
+
   final String id;
   final String? nameId;
   final String? icon;
@@ -9,7 +12,12 @@ class DappDto {
   final String? description;
   final String? name;
   final String? openButtonTitle;
-  final List<String>? excludedPlatforms;
+
+  /// Platform-specific version constraints (semver format: ">=1.0.0", "^2.0.0")
+  /// Keys: 'ios', 'android', 'macos', 'windows', 'linux', 'web'
+  /// Use [versionNone] to exclude a platform entirely
+  /// If a platform is not in the map, the dApp is available on all versions of that platform
+  final Map<String, String>? platformVersions;
 
   DappDto({
     required this.id,
@@ -22,7 +30,7 @@ class DappDto {
     this.description,
     this.name,
     this.openButtonTitle,
-    this.excludedPlatforms,
+    this.platformVersions,
   });
 
   factory DappDto.fromJson(Map<String, dynamic> json) {
@@ -35,8 +43,8 @@ class DappDto {
       customDescriptionId: json['customDescriptionId'],
       openButtonTitleId: json['openButtonTitleId'],
       openButtonTitle: json['openButtonTitle'],
-      excludedPlatforms: json['excludedPlatforms'] != null
-          ? List<String>.from(json['excludedPlatforms'])
+      platformVersions: json['platformVersions'] != null
+          ? Map<String, String>.from(json['platformVersions'])
           : null,
     );
   }
@@ -52,7 +60,7 @@ class DappDto {
     String? name,
     String? openButtonTitleId,
     String? openButtonTitle,
-    List<String>? excludedPlatforms,
+    Map<String, String>? platformVersions,
   }) {
     return DappDto(
       id: id ?? this.id,
@@ -65,13 +73,13 @@ class DappDto {
       name: name ?? this.name,
       openButtonTitleId: openButtonTitleId ?? this.openButtonTitleId,
       openButtonTitle: openButtonTitle ?? this.openButtonTitle,
-      excludedPlatforms: excludedPlatforms ?? this.excludedPlatforms,
+      platformVersions: platformVersions ?? this.platformVersions,
     );
   }
 
   @override
   String toString() {
-    return 'DappDto(id: $id, nameId: $nameId, icon: $icon, url: $url, descriptionId: $descriptionId, customDescriptionId: $customDescriptionId, description: $description, name: $name openButtonTitle: $openButtonTitle, excludedPlatforms: $excludedPlatforms)';
+    return 'DappDto(id: $id, nameId: $nameId, icon: $icon, url: $url, descriptionId: $descriptionId, customDescriptionId: $customDescriptionId, description: $description, name: $name, openButtonTitle: $openButtonTitle, platformVersions: $platformVersions)';
   }
 }
 


### PR DESCRIPTION
- Add platformVersions field to DappDto for per-platform version filtering
- Support "none" value to exclude platform entirely
- Remove excludedPlatforms (replaced by platformVersions)
- Use restrictive approach: hide dApps on version check failure