### PR TITLE
fix: distinguish tokens with same name by issuer identity

### DIFF
--- a/lib/components/grouped_asset_item.dart
+++ b/lib/components/grouped_asset_item.dart
@@ -5,6 +5,7 @@ import 'package:qubic_wallet/di.dart';
 import 'package:qubic_wallet/dtos/grouped_asset_dto.dart';
 import 'package:qubic_wallet/extensions/as_thousands.dart';
 import 'package:qubic_wallet/flutter_flow/theme_paddings.dart';
+import 'package:qubic_wallet/helpers/address_ui_helper.dart';
 import 'package:qubic_wallet/helpers/explorer_helpers.dart';
 import 'package:qubic_wallet/l10n/l10n.dart';
 import 'package:qubic_wallet/models/qubic_list_vm.dart';
@@ -118,20 +119,33 @@ class GroupedAssetItem extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Expanded(
-                      child: AmountFormatted(
-                        key: ValueKey<String>(
-                            "qubicAsset${account.publicId}-${groupedAsset.tokenName}-${groupedAsset.totalUnits}"),
-                        amount: groupedAsset.totalUnits,
-                        isInHeader: false,
-                        labelOffset: -0,
-                        labelHorizOffset: -6,
-                        textStyle: MediaQuery.of(context).size.width < 400
-                            ? TextStyles.accountAmount.copyWith(fontSize: 20)
-                            : TextStyles.accountAmount,
-                        labelStyle: TextStyles.accountAmountLabel,
-                        currencyName: groupedAsset.tokenName,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          AmountFormatted(
+                            key: ValueKey<String>(
+                                "qubicAsset${account.publicId}-${groupedAsset.tokenName}-${groupedAsset.totalUnits}"),
+                            amount: groupedAsset.totalUnits,
+                            isInHeader: false,
+                            labelOffset: -0,
+                            labelHorizOffset: -6,
+                            textStyle: MediaQuery.of(context).size.width < 400
+                                ? TextStyles.accountAmount.copyWith(fontSize: 20)
+                                : TextStyles.accountAmount,
+                            labelStyle: TextStyles.accountAmountLabel,
+                            currencyName: groupedAsset.tokenName,
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.only(top: ThemePaddings.tinyPadding),
+                            child: Text(
+                              l10n.assetsIssuedBy(AddressUIHelper.truncateAddress(groupedAsset.issuedAsset.issuerIdentity)),
+                              style: TextStyles.secondaryTextSmall,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                     getCardMenu(context),

--- a/lib/helpers/address_ui_helper.dart
+++ b/lib/helpers/address_ui_helper.dart
@@ -12,4 +12,13 @@ class AddressUIHelper {
   static String? getLabel(String address) {
     return _ecosystemStore.getEntityLabel(address);
   }
+
+  static const _truncateLength = 4;
+
+  /// Truncates an address to show first and last [_truncateLength] characters.
+  /// Example: "ABCDEFGHIJKLMNOP..." becomes "ABCD...MNOP"
+  static String truncateAddress(String address) {
+    if (address.length <= _truncateLength * 2) return address;
+    return '${address.substring(0, _truncateLength)}...${address.substring(address.length - _truncateLength)}';
+  }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -228,6 +228,14 @@
     "assetsLabelContractName": "Vertragsname",
     "assetsLabelContractIndex": "Vertragsindex",
     "assetsManagedBy": "verwaltet von",
+    "assetsIssuedBy": "Ausgegeben von {address}",
+    "@assetsIssuedBy": {
+        "placeholders": {
+            "address": {
+                "type": "String"
+            }
+        }
+    },
     "assetsLabelCurrentBalance": "Guthaben in ID: {amount} QUBIC",
     "@assetsLabelCurrentBalance": {
         "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -266,6 +266,14 @@
     "assetsLabelContractName": "Contract Name",
     "assetsLabelContractIndex": "Contract Index",
     "assetsManagedBy": "managed by",
+    "assetsIssuedBy": "Issued by {address}",
+    "@assetsIssuedBy": {
+        "placeholders": {
+            "address": {
+                "type": "String"
+            }
+        }
+    },
     "assetsLabelCurrentBalance": "Balance in ID: {amount} QUBIC",
     "@assetsLabelCurrentBalance": {
         "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -227,6 +227,14 @@
     "assetsLabelContractName": "Nombre del Contrato",
     "assetsLabelContractIndex": "Índice del Contrato",
     "assetsManagedBy": "gestionado por",
+    "assetsIssuedBy": "Emitido por {address}",
+    "@assetsIssuedBy": {
+        "placeholders": {
+            "address": {
+                "type": "String"
+            }
+        }
+    },
     "assetsLabelCurrentBalance": "Balance en la cuenta: {amount} QUBIC",
     "@assetsLabelCurrentBalance": {
         "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -228,6 +228,14 @@
     "assetsLabelContractName": "Nom du contrat",
     "assetsLabelContractIndex": "Index du contrat",
     "assetsManagedBy": "géré par",
+    "assetsIssuedBy": "Émis par {address}",
+    "@assetsIssuedBy": {
+        "placeholders": {
+            "address": {
+                "type": "String"
+            }
+        }
+    },
     "assetsLabelCurrentBalance": "Solde en ID: {amount} QUBIC",
     "@assetsLabelCurrentBalance": {
         "placeholders": {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -228,6 +228,14 @@
     "assetsLabelContractName": "Имя контракта",
     "assetsLabelContractIndex": "Индекс контракта",
     "assetsManagedBy": "управляется",
+    "assetsIssuedBy": "Выпущено {address}",
+    "@assetsIssuedBy": {
+        "placeholders": {
+            "address": {
+                "type": "String"
+            }
+        }
+    },
     "assetsLabelCurrentBalance": "Балланс ID: {amount} QUBIC",
     "@assetsLabelCurrentBalance": {
         "placeholders": {

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -228,6 +228,14 @@
     "assetsLabelContractName": "Kontrakt Adı",
     "assetsLabelContractIndex": "Kontrakt İndeksi",
     "assetsManagedBy": "yöneten",
+    "assetsIssuedBy": "{address} tarafından yayınlandı",
+    "@assetsIssuedBy": {
+        "placeholders": {
+            "address": {
+                "type": "String"
+            }
+        }
+    },
     "assetsLabelCurrentBalance": "ID'deki Bakiye: {amount} QUBIC",
     "@assetsLabelCurrentBalance": {
         "placeholders": {

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -260,6 +260,14 @@
     "assetsLabelContractName": "Tên hợp đồng",
     "assetsLabelContractIndex": "Chỉ mục hợp đồng",
     "assetsManagedBy": "được quản lý bởi",
+    "assetsIssuedBy": "Được phát hành bởi {address}",
+    "@assetsIssuedBy": {
+        "placeholders": {
+            "address": {
+                "type": "String"
+            }
+        }
+    },
     "assetsLabelCurrentBalance": "Số dư trong ID: {amount} QUBIC",
     "@assetsLabelCurrentBalance": {
         "placeholders": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -228,6 +228,14 @@
     "assetsLabelContractName": "合约名称",
     "assetsLabelContractIndex": "合约索引",
     "assetsManagedBy": "管理者",
+    "assetsIssuedBy": "由 {address} 发行",
+    "@assetsIssuedBy": {
+        "placeholders": {
+            "address": {
+                "type": "String"
+            }
+        }
+    },
     "assetsLabelCurrentBalance": "ID 中余额： {amount} QUBIC",
     "@assetsLabelCurrentBalance": {
         "placeholders": {

--- a/lib/models/qubic_list_vm.dart
+++ b/lib/models/qubic_list_vm.dart
@@ -63,8 +63,9 @@ class QubicListVm {
     Map<String, QubicAssetDto> mergedAssets = {};
 
     for (int i = 0; i < newAssets.length; i++) {
+      // Include issuer identity to distinguish tokens with same name but different issuers
       String name =
-          "${newAssets[i].issuedAsset.name}-${newAssets[i].managingContractIndex}";
+          "${newAssets[i].issuedAsset.issuerIdentity}_${newAssets[i].issuedAsset.name}-${newAssets[i].managingContractIndex}";
       if (mergedAssets.containsKey(name)) {
         if (mergedAssets[name]!.info.tick < newAssets[i].info.tick) {
           mergedAssets[name] = newAssets[i];


### PR DESCRIPTION
- Include issuer identity in asset grouping key to fix bug where tokens with same name but different issuers would overwrite each other
- Add "Issued by XXXX...YYYY" label below token name in asset list
- Add truncateAddress() utility to AddressUIHelper
- Add assetsIssuedBy localization string for all languages

Fixes #596