### PR TITLE
fix: require own account for WalletConnect connections

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -395,6 +395,7 @@
     "deleteAccountDialogTitle": "Konto löschen",
     "deleteAccountDialogMessage": "Sind Sie sicher, dass Sie dieses Qubic-Konto aus Ihrem Wallet löschen möchten? (Alle mit diesem Konto verbundenen Gelder werden nicht entfernt)\n\nSTELLEN SIE SICHER, DASS SIE EINE SICHERUNG IHRER PRIVATEN SEED HABEN, BEVOR SIE DIESES KONTO LÖSCHEN!",
     "deleteAccountDialogButtonDelete": "Konto löschen",
+    "errorNoAccountsForWalletConnect": "Fügen Sie Ihr eigenes Konto hinzu, um sich mit dApps zu verbinden.",
     "renameAccountDialogTitle": "Konto umbenennen",
     "renameAccountLabelName": "Name",
     "renameAccountDialogHintName": "Neuer Name",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -455,6 +455,7 @@
     "deleteAccountDialogMessage": "Are you sure you want to delete this Qubic Account from your wallet? (Any funds associated with this Account will not be removed)\n\nMAKE SURE YOU HAVE A BACKUP OF YOUR PRIVATE SEED BEFORE DELETING THIS ACCOUNT!",
     "deleteAccountDialogMessageWatchOnly": "Are you sure you want to delete this watch only Account from your wallet?",
     "deleteAccountDialogButtonDelete": "Delete Account",
+    "errorNoAccountsForWalletConnect": "Add your own account to connect to dApps.",
     "renameAccountDialogTitle": "Rename Account",
     "renameAccountLabelName": "Name",
     "renameAccountDialogHintName": "New name",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -394,6 +394,7 @@
     "deleteAccountDialogTitle": "Eliminar Cuenta",
     "deleteAccountDialogMessage": "¿Estás seguro que quieres eliminar esta cuenta de tu Wallet? (Los fondos asociados no serán removidos)\n\n!ASEGÚRATE DE TENER UNA COPIA DE RESPALDO DE TU SEMILLA PRIVADA ANTES DE ELIMINAR ESTA CUENTA!",
     "deleteAccountDialogButtonDelete": "Eliminar Cuenta",
+    "errorNoAccountsForWalletConnect": "Agrega tu propia cuenta para conectarte a dApps.",
     "renameAccountDialogTitle": "Renombrar Cuenta",
     "renameAccountLabelName": "Nombre",
     "renameAccountDialogHintName": "Nuevo nombre",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -395,6 +395,7 @@
     "deleteAccountDialogTitle": "Supprimer le Compte",
     "deleteAccountDialogMessage": "Êtes-vous sûr de vouloir supprimer ce compte Qubic de votre portefeuille ? (Les fonds associés à ce compte ne seront pas supprimés)\n\nASSUREZ-VOUS D'AVOIR UNE SAUVEGARDE DE VOTRE SEED PRIVÉE AVANT DE SUPPRIMER CE COMPTE !",
     "deleteAccountDialogButtonDelete": "Supprimer le Compte",
+    "errorNoAccountsForWalletConnect": "Ajoutez votre propre compte pour vous connecter aux dApps.",
     "renameAccountDialogTitle": "Renommer le Compte",
     "renameAccountLabelName": "Nom",
     "renameAccountDialogHintName": "Nouveau nom",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -394,6 +394,7 @@
     "deleteAccountDialogTitle": "Удалить аккаунт",
     "deleteAccountDialogMessage": "Вы уверены, что хотите удалить этот аккаунт Qubic из своего кошелька? (Все средства, связанные с этим счетом, не будут удалены)\n\nУБЕДИТЕСЬ, ЧТО У ВАС ЕСТЬ РЕЗЕРВНАЯ КОПИЯ СЕКРЕТНОГО СИДА ПЕРЕД УДАЛЕНИЕМ ЭТОГО АККАУНТА!",
     "deleteAccountDialogButtonDelete": "Удалить аккаунт",
+    "errorNoAccountsForWalletConnect": "Добавьте свой аккаунт для подключения к dApps.",
     "renameAccountDialogTitle": "Переименовать аккаунт",
     "renameAccountLabelName": "Имя",
     "renameAccountDialogHintName": "Новое имя",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -395,6 +395,7 @@
     "deleteAccountDialogTitle": "Hesabı Sil",
     "deleteAccountDialogMessage": "Bu Qubic Hesabını cüzdanınızdan silmek istediğinizden emin misiniz? (Bu Hesaba bağlı herhangi bir fon kaldırılmayacaktır)\n\nBU HESABI SİLMEDEN ÖNCE ÖZEL ANAHTARINIZIN YEDEKLEĞİNİZDEN EMİN OLUN!",
     "deleteAccountDialogButtonDelete": "Hesabı Sil",
+    "errorNoAccountsForWalletConnect": "dApps'e bağlanmak için kendi hesabınızı ekleyin.",
     "renameAccountDialogTitle": "Hesabın Adını Değiştir",
     "renameAccountLabelName": "Ad",
     "renameAccountDialogHintName": "Yeni Ad",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -442,6 +442,7 @@
     "deleteAccountDialogMessage": "Bạn có chắc chắn muốn xóa tài khoản Qubic này khỏi ví của bạn không? (Bất kỳ số tiền nào liên quan đến tài khoản này sẽ không bị xóa)\n\nĐẢM BẢO BẠN ĐÃ CÓ BẢN SAO LƯU SEED RIÊNG TƯ TRƯỚC KHI XÓA TÀI KHOẢN NÀY!",
     "deleteAccountDialogMessageWatchOnly": "Bạn có chắc chắn muốn xóa tài khoản chỉ xem này khỏi ví của bạn không?",
     "deleteAccountDialogButtonDelete": "Xóa tài khoản",
+    "errorNoAccountsForWalletConnect": "Thêm tài khoản của bạn để kết nối với dApps.",
     "renameAccountDialogTitle": "Đổi tên tài khoản",
     "renameAccountLabelName": "Tên",
     "renameAccountDialogHintName": "Tên mới",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -395,6 +395,7 @@
     "deleteAccountDialogTitle": "删除账户",
     "deleteAccountDialogMessage": "您确定要从钱包中删除此 Qubic 账户吗？（与该账户关联的任何资金不会被移除）\n\n在删除此帐户之前，请确保已备份您的私有种子！",
     "deleteAccountDialogButtonDelete": "删除账户",
+    "errorNoAccountsForWalletConnect": "添加您自己的账户以连接到 dApps。",
     "renameAccountDialogTitle": "重命名账户",
     "renameAccountLabelName": "名称",
     "renameAccountDialogHintName": "新名称",

--- a/lib/models/app_link/app_link_controller.dart
+++ b/lib/models/app_link/app_link_controller.dart
@@ -48,6 +48,9 @@ class AppLinkController {
     if (getIt<RootJailbreakFlagStore>().restrictFeatureIfDeviceCompromised()) {
       return;
     }
+    if (_applicationStore.nonWatchOnlyAccounts.isEmpty) {
+      throw Exception(l10n.errorNoAccountsForWalletConnect);
+    }
     await pushScreen(
       context,
       screen:

--- a/lib/pages/main/tab_wallet_contents.dart
+++ b/lib/pages/main/tab_wallet_contents.dart
@@ -217,6 +217,28 @@ class _TabWalletContentsState extends State<TabWalletContents> {
                                   .restrictFeatureIfDeviceCompromised()) {
                                 return;
                               }
+                              if (appStore.nonWatchOnlyAccounts.isEmpty) {
+                                showDialog(
+                                  context: context,
+                                  builder: (BuildContext dialogContext) {
+                                    return AlertDialog(
+                                      title: Text(l10n.settingsLabelWalletConnect,
+                                          style: TextStyles.alertHeader),
+                                      content: Text(
+                                          l10n.errorNoAccountsForWalletConnect,
+                                          style: TextStyles.alertText),
+                                      actions: [
+                                        ThemedControls.primaryButtonNormal(
+                                          text: l10n.generalButtonOK,
+                                          onPressed: () =>
+                                              Navigator.pop(dialogContext),
+                                        ),
+                                      ],
+                                    );
+                                  },
+                                );
+                                return;
+                              }
                               pushScreen(
                                 context,
                                 screen: const AddWalletConnect(),

--- a/lib/pages/main/wallet_contents/settings/wallet_connect/wallet_connect.dart
+++ b/lib/pages/main/wallet_contents/settings/wallet_connect/wallet_connect.dart
@@ -12,6 +12,7 @@ import 'package:qubic_wallet/l10n/l10n.dart';
 import 'package:qubic_wallet/pages/main/wallet_contents/add_wallet_connect/add_wallet_connect.dart';
 import 'package:qubic_wallet/pages/main/wallet_contents/settings/wallet_connect/components/wallet_connect_expansion_card.dart';
 import 'package:qubic_wallet/services/wallet_connect_service.dart';
+import 'package:qubic_wallet/stores/application_store.dart';
 import 'package:qubic_wallet/stores/root_jailbreak_flag_store.dart';
 import 'package:qubic_wallet/styles/app_icons.dart';
 import 'package:qubic_wallet/styles/button_styles.dart';
@@ -32,6 +33,7 @@ class WalletConnectSettings extends StatefulWidget {
 class _WalletConnectSettingsState extends State<WalletConnectSettings> {
   final WalletConnectService walletConnectService =
       getIt<WalletConnectService>();
+  final ApplicationStore _appStore = getIt<ApplicationStore>();
 
   Map<String, SessionData> sessions = {};
 
@@ -68,6 +70,33 @@ class _WalletConnectSettingsState extends State<WalletConnectSettings> {
         });
       });
     }
+  }
+
+  /// Returns true if there are non-watch-only accounts, false otherwise.
+  /// Shows an error dialog if there are no accounts.
+  bool _checkHasAccounts() {
+    if (_appStore.nonWatchOnlyAccounts.isEmpty) {
+      final l10n = l10nOf(context);
+      showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title:
+                Text(l10n.settingsLabelWalletConnect, style: TextStyles.alertHeader),
+            content: Text(l10n.errorNoAccountsForWalletConnect,
+                style: TextStyles.alertText),
+            actions: [
+              ThemedControls.primaryButtonNormal(
+                text: l10n.generalButtonOK,
+                onPressed: () => Navigator.pop(context),
+              ),
+            ],
+          );
+        },
+      );
+      return false;
+    }
+    return true;
   }
 
   List<String> getMethods(SessionData sessionData) {
@@ -270,6 +299,7 @@ class _WalletConnectSettingsState extends State<WalletConnectSettings> {
                       .restrictFeatureIfDeviceCompromised()) {
                     return;
                   }
+                  if (!_checkHasAccounts()) return;
                   await pushScreen(
                     context,
                     screen: const AddWalletConnect(),
@@ -311,6 +341,7 @@ class _WalletConnectSettingsState extends State<WalletConnectSettings> {
                     .restrictFeatureIfDeviceCompromised()) {
                   return;
                 }
+                if (!_checkHasAccounts()) return;
                 await pushScreen(
                   context,
                   screen: const AddWalletConnect(),


### PR DESCRIPTION
Add validation to all WalletConnect entry points to ensure user has a non-watch-only account before connecting to dApps. Shows error dialog with message "Add your own account to connect to dApps."