### PR TITLE
chore: remove unused downloadsfolder dependency and WRITE_EXTERNAL_STORAGE permission

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,6 +4,5 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
 
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
         android:name="android.permission.ACCESS_FINE_LOCATION"
         tools:node="remove" />
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
 
     <application
         android:label="Qubic Wallet"

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -4,6 +4,5 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
 
 </manifest>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,6 @@ dependencies:
   decimal: ^3.0.2
   animated_snack_bar: ^0.4.0
   file_picker: ^8.0.6
-  downloadsfolder: ^1.1.0
   privacy_screen: ^0.0.6
   reown_walletkit: 1.1.3
   blur: ^4.0.0


### PR DESCRIPTION
## Summary

- Remove unused `downloadsfolder` dependency from `pubspec.yaml` (not imported anywhere in the codebase)
- Remove `WRITE_EXTERNAL_STORAGE` permission from all Android manifests (was only needed by `downloadsfolder`)

Closes #161