### PR TITLE
chore: fix analyzer warnings

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -37,8 +37,6 @@ PODS:
   - DKPhotoGallery/Resource (0.0.19):
     - SDWebImage
     - SwiftyGif
-  - downloadsfolder (0.0.1):
-    - Flutter
   - DTTJailbreakDetection (0.4.0)
   - file_picker (0.0.1):
     - DKImagePickerController/PhotoGallery
@@ -148,7 +146,6 @@ DEPENDENCIES:
   - Argon2Swift
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - cryptography_flutter (from `.symlinks/plugins/cryptography_flutter/ios`)
-  - downloadsfolder (from `.symlinks/plugins/downloadsfolder/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
@@ -197,8 +194,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/connectivity_plus/ios"
   cryptography_flutter:
     :path: ".symlinks/plugins/cryptography_flutter/ios"
-  downloadsfolder:
-    :path: ".symlinks/plugins/downloadsfolder/ios"
   file_picker:
     :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
@@ -241,7 +236,6 @@ SPEC CHECKSUMS:
   cryptography_flutter: 70166b3780db39960caf51fd90fe308bec22d3f1
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  downloadsfolder: 7d5c7b5d23e3c4dded522ff2a2ef14a56846378a
   DTTJailbreakDetection: 5e356c5badc17995f65a83ed9483f787a0057b71
   file_picker: 9b3292d7c8bc68c8a7bf8eb78f730e49c8efc517
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -110,9 +110,8 @@ PODS:
     - nanopb/encode (= 2.30910.0)
   - nanopb/decode (2.30910.0)
   - nanopb/encode (2.30910.0)
-  - "no_screenshot (0.0.1+4)":
+  - no_screenshot (0.3.2-beta.3):
     - Flutter
-    - ScreenProtectorKit (~> 1.3.1)
   - OrderedSet (6.0.3)
   - package_info_plus (0.4.5):
     - Flutter
@@ -125,7 +124,6 @@ PODS:
   - safe_device (1.0.0):
     - DTTJailbreakDetection
     - Flutter
-  - ScreenProtectorKit (1.3.1)
   - SDWebImage (5.19.7):
     - SDWebImage/Core (= 5.19.7)
   - SDWebImage/Core (5.19.7)
@@ -183,7 +181,6 @@ SPEC REPOS:
     - nanopb
     - OrderedSet
     - PromisesObjC
-    - ScreenProtectorKit
     - SDWebImage
     - SwiftyGif
 
@@ -256,14 +253,13 @@ SPEC CHECKSUMS:
   MLKitVision: e858c5f125ecc288e4a31127928301eaba9ae0c1
   mobile_scanner: 92e8812bf22a8f84131e2a7f9d0f44dad1a4742b
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
-  no_screenshot: 6d183496405a3ab709a67a54e5cd0f639e94729e
+  no_screenshot: 5e345998c43ffcad5d6834f249590483fcc037bd
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   privacy_screen: 3159a541f5d3a31bea916cfd4e58f9dc722b3fd4
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   safe_device: 2573e42a36900686b7bf02a87ac60c5c3a79a015
-  ScreenProtectorKit: 83a6281b02c7a5902ee6eac4f5045f674e902ae4
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -57,7 +57,12 @@ abstract class Config {
   static addressAssetsBalance(String address) =>
       "$liveApiPrefix/assets/$address/owned";
   static const assets = "$liveApiPrefix/assets/issuances";
-  static const latestStatsUrl = "$liveApiPrefix/latest-stats";
+
+  // ---------------------------------------------------------------------------
+  // RPC API Endpoints — Stats
+  // ---------------------------------------------------------------------------
+
+  static const latestStatsUrl = "/v1/latest-stats";
 
   // ---------------------------------------------------------------------------
   // HTTP

--- a/lib/models/wallet_connect/wallet_connect_modals_controller.dart
+++ b/lib/models/wallet_connect/wallet_connect_modals_controller.dart
@@ -15,7 +15,6 @@ import 'package:qubic_wallet/models/wallet_connect/request_sign_message_event.da
 import 'package:qubic_wallet/models/wallet_connect/request_sign_message_result.dart';
 import 'package:qubic_wallet/models/wallet_connect/request_sign_transaction_result.dart';
 import 'package:qubic_wallet/resources/apis/live/qubic_live_api.dart';
-import 'package:qubic_wallet/smart_contracts/qutil_info.dart';
 import 'package:reown_walletkit/reown_walletkit.dart';
 
 // Provides a unified place to handle WalletConnect modals

--- a/lib/stores/application_store.dart
+++ b/lib/stores/application_store.dart
@@ -188,7 +188,7 @@ abstract class _ApplicationStore with Store {
   List<QubicAssetDto> get totalShares {
     List<QubicAssetDto> shares = [];
     List<QubicAssetDto> tokens = [];
-    nonWatchOnlyAccounts.forEach((id) {
+    for (final id in nonWatchOnlyAccounts) {
       id.assets.forEach((key, asset) {
         QubicAssetDto temp = asset;
 
@@ -212,7 +212,7 @@ abstract class _ApplicationStore with Store {
           }
         }
       });
-    });
+    }
 
     List<QubicAssetDto> result = [];
     result.addAll(shares);

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <flutter_is_ios_app_on_mac/flutter_is_ios_app_on_mac_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <gtk/gtk_plugin.h>
+#include <no_screenshot/no_screenshot_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
@@ -23,6 +24,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
+  g_autoptr(FlPluginRegistrar) no_screenshot_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "NoScreenshotPlugin");
+  no_screenshot_plugin_register_with_registrar(no_screenshot_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
   screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_is_ios_app_on_mac
   flutter_secure_storage_linux
   gtk
+  no_screenshot
   screen_retriever
   url_launcher_linux
   window_manager

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -32,7 +32,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FLALocalAuthPlugin.register(with: registry.registrar(forPlugin: "FLALocalAuthPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
-  NoScreenshotPlugin.register(with: registry.registrar(forPlugin: "NoScreenshotPlugin"))
+  MacOSNoScreenshotPlugin.register(with: registry.registrar(forPlugin: "MacOSNoScreenshotPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,7 +8,6 @@ import Foundation
 import app_links
 import connectivity_plus
 import cryptography_flutter
-import downloadsfolder
 import flutter_inappwebview_macos
 import flutter_is_ios_app_on_mac
 import flutter_secure_storage_macos
@@ -28,7 +27,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   CryptographyFlutterPlugin.register(with: registry.registrar(forPlugin: "CryptographyFlutterPlugin"))
-  DownloadsfolderPlugin.register(with: registry.registrar(forPlugin: "DownloadsfolderPlugin"))
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterIsIosAppOnMacPlugin.register(with: registry.registrar(forPlugin: "FlutterIsIosAppOnMacPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,18 +1,15 @@
 PODS:
   - app_links (1.0.0):
     - FlutterMacOS
-  - Argon2Swift (1.0.4)
   - connectivity_plus (0.0.1):
-    - Flutter
     - FlutterMacOS
-  - dargon2_flutter_desktop (0.0.1):
-    - Argon2Swift
-    - FlutterMacOS
-  - downloadsfolder (0.0.1):
+  - cryptography_flutter (0.2.0):
     - FlutterMacOS
   - flutter_inappwebview_macos (0.0.1):
     - FlutterMacOS
     - OrderedSet (~> 6.0.3)
+  - flutter_is_ios_app_on_mac (0.0.1):
+    - FlutterMacOS
   - flutter_secure_storage_macos (6.1.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
@@ -20,6 +17,8 @@ PODS:
     - Flutter
     - FlutterMacOS
   - mobile_scanner (5.2.3):
+    - FlutterMacOS
+  - no_screenshot (0.3.2-beta.3):
     - FlutterMacOS
   - OrderedSet (6.0.3)
   - package_info_plus (0.0.1):
@@ -34,6 +33,9 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - sqflite_darwin (0.0.4):
+    - Flutter
+    - FlutterMacOS
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
   - window_manager (0.2.0):
@@ -41,38 +43,39 @@ PODS:
 
 DEPENDENCIES:
   - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
-  - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/darwin`)
-  - dargon2_flutter_desktop (from `Flutter/ephemeral/.symlinks/plugins/dargon2_flutter_desktop/macos`)
-  - downloadsfolder (from `Flutter/ephemeral/.symlinks/plugins/downloadsfolder/macos`)
+  - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
+  - cryptography_flutter (from `Flutter/ephemeral/.symlinks/plugins/cryptography_flutter/macos`)
   - flutter_inappwebview_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos`)
+  - flutter_is_ios_app_on_mac (from `Flutter/ephemeral/.symlinks/plugins/flutter_is_ios_app_on_mac/macos`)
   - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
   - mobile_scanner (from `Flutter/ephemeral/.symlinks/plugins/mobile_scanner/macos`)
+  - no_screenshot (from `Flutter/ephemeral/.symlinks/plugins/no_screenshot/macos`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - screen_retriever (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sqflite_darwin (from `Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 SPEC REPOS:
   trunk:
-    - Argon2Swift
     - OrderedSet
 
 EXTERNAL SOURCES:
   app_links:
     :path: Flutter/ephemeral/.symlinks/plugins/app_links/macos
   connectivity_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/darwin
-  dargon2_flutter_desktop:
-    :path: Flutter/ephemeral/.symlinks/plugins/dargon2_flutter_desktop/macos
-  downloadsfolder:
-    :path: Flutter/ephemeral/.symlinks/plugins/downloadsfolder/macos
+    :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos
+  cryptography_flutter:
+    :path: Flutter/ephemeral/.symlinks/plugins/cryptography_flutter/macos
   flutter_inappwebview_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos
+  flutter_is_ios_app_on_mac:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_is_ios_app_on_mac/macos
   flutter_secure_storage_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
   FlutterMacOS:
@@ -81,6 +84,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin
   mobile_scanner:
     :path: Flutter/ephemeral/.symlinks/plugins/mobile_scanner/macos
+  no_screenshot:
+    :path: Flutter/ephemeral/.symlinks/plugins/no_screenshot/macos
   package_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   path_provider_foundation:
@@ -91,30 +96,33 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  sqflite_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   window_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
-  app_links: 10e0a0ab602ffaf34d142cd4862f29d34b303b2a
-  Argon2Swift: 295b8bde7ba61434f227f5610b8813c42e866f74
-  connectivity_plus: 18382e7311ba19efcaee94442b23b32507b20695
-  dargon2_flutter_desktop: 5c9ada7e2681da7dc95052e4fcc1e61ad17e27e1
-  downloadsfolder: f8c4d35588cc58b607898ebbbdbeb5c0e7f04a46
-  flutter_inappwebview_macos: bdf207b8f4ebd58e86ae06cd96b147de99a67c9b
-  flutter_secure_storage_macos: 59459653abe1adb92abbc8ea747d79f8d19866c9
+  app_links: 9028728e32c83a0831d9db8cf91c526d16cc5468
+  connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
+  cryptography_flutter: 33e8726fef117a6f306382f6fa34e173642cc64f
+  flutter_inappwebview_macos: c2d68649f9f8f1831bfcd98d73fd6256366d9d1d
+  flutter_is_ios_app_on_mac: b6861fc03b2c78baa75ad6122068f9dc8e8aada2
+  flutter_secure_storage_macos: b2d62a774c23b060f0b99d0173b0b36abb4a8632
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  local_auth_darwin: 66e40372f1c29f383a314c738c7446e2f7fdadc3
-  mobile_scanner: 0a05256215b047af27b9495db3b77640055e8824
+  local_auth_darwin: 553ce4f9b16d3fdfeafce9cf042e7c9f77c1c391
+  mobile_scanner: bd1e7cd9b67b442f4d903747f4778e040513f860
+  no_screenshot: 793cd7e1a158fa2d8be095473105d51e60583b66
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: 12f1c5c2cfe8727ca46cbd0b26677728972d9a5b
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
-  share_plus: 1fa619de8392a4398bfaf176d441853922614e89
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
-  window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
+  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  screen_retriever: 4f97c103641aab8ce183fa5af3b87029df167936
+  share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
+  window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
 
 PODFILE CHECKSUM: cd4de04520a2f183f35981be9c3a084d83c36222
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1364,7 +1364,7 @@ packages:
     source: hosted
     version: "6.1.2"
   pub_semver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pub_semver
       sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -375,14 +375,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.7"
-  dartx:
-    dependency: transitive
-    description:
-      name: dartx
-      sha256: "8b25435617027257d43e6508b5fe061012880ddfdaa75a71d607c3de2a13d244"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
   dbus:
     dependency: transitive
     description:
@@ -399,14 +391,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  diacritic:
-    dependency: transitive
-    description:
-      name: diacritic
-      sha256: "12981945ec38931748836cd76f2b38773118d0baef3c68404bdfde9566147876"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.6"
   dio:
     dependency: "direct main"
     description:
@@ -431,14 +415,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
-  downloadsfolder:
-    dependency: "direct main"
-    description:
-      name: downloadsfolder
-      sha256: "0e1bb7dd634d6231c0ac116c467da94507a07ed62239712ea0dead981d58b114"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
   ed25519_edwards:
     dependency: transitive
     description:
@@ -1736,14 +1712,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.3"
-  time:
-    dependency: transitive
-    description:
-      name: time
-      sha256: "370572cf5d1e58adcb3e354c47515da3f7469dac3a95b447117e728e7be6f461"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.5"
   timeago:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1159,10 +1159,10 @@ packages:
     dependency: "direct main"
     description:
       name: no_screenshot
-      sha256: ec3d86d7ee89a09c3a3939c1003012536ba4b3fcb4f8cbd23d87ada595c99258
+      sha256: "967ae6356a7e83b44bebed2e72c8a4bb0b5f0f9032a1e57cdeccff05bfedd84d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1"
+    version: "0.3.6"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,7 @@ dependencies:
   no_screenshot: ^0.3.1
   implicitly_animated_list: ^2.3.0
   cached_network_image: ^3.4.1
+  pub_semver: ^2.1.5
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,7 +75,7 @@ dependencies:
   safe_device: ^1.2.1
   flutter_is_ios_app_on_mac: ^1.0.1
   cryptography: ^2.7.0
-  no_screenshot: ^0.3.1
+  no_screenshot: ^0.3.6
   implicitly_animated_list: ^2.3.0
   cached_network_image: ^3.4.1
   pub_semver: ^2.1.5

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,7 +8,6 @@
 
 #include <app_links/app_links_plugin_c_api.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
-#include <downloadsfolder/downloadsfolder_plugin_c_api.h>
 #include <flutter_inappwebview_windows/flutter_inappwebview_windows_plugin_c_api.h>
 #include <flutter_is_ios_app_on_mac/flutter_is_ios_app_on_mac_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
@@ -23,8 +22,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
-  DownloadsfolderPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("DownloadsfolderPluginCApi"));
   FlutterInappwebviewWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterInappwebviewWindowsPluginCApi"));
   FlutterIsIosAppOnMacPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,7 +5,6 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
   connectivity_plus
-  downloadsfolder
   flutter_inappwebview_windows
   flutter_is_ios_app_on_mac
   flutter_secure_storage_windows


### PR DESCRIPTION
Clears the three warnings from `flutter analyze`:

- Unused `qutil_info` import in `WalletConnectModalsController`.
- `forEach` with function literal in `ApplicationStore.totalShares` → `for-in`.
- `pub_semver` was imported in `WalletContentStore` but only pulled in transitively → declared as a direct dependency.

Also folds in a lockfile regeneration commit: PR #633 removed `downloadsfolder` but the committed `pubspec.lock` / plugin registrants hadn't been regenerated.