### PR TITLE
fix: sign verify message

### DIFF
--- a/lib/pages/main/wallet_contents/sign_message.dart
+++ b/lib/pages/main/wallet_contents/sign_message.dart
@@ -127,7 +127,7 @@ class _SignMessageScreenState extends State<SignMessageScreen> {
               TextFormField(
                 controller: _messageController,
                 maxLines: 3,
-                decoration: ThemeInputDecorations.bigInputbox.copyWith(
+                decoration: ThemeInputDecorations.bigInputboxCompact.copyWith(
                   hintText: l10n.signVerifyMessageEnterMessage,
                   suffixIcon: _messageController.text.isNotEmpty
                       ? IconButton(
@@ -181,7 +181,7 @@ class _SignMessageScreenState extends State<SignMessageScreen> {
                   initialValue: signOutput,
                   readOnly: true,
                   maxLines: null,
-                  decoration: ThemeInputDecorations.bigInputbox,
+                  decoration: ThemeInputDecorations.bigInputboxCompact,
                 ),
               ],
             ],

--- a/lib/pages/main/wallet_contents/sign_message.dart
+++ b/lib/pages/main/wallet_contents/sign_message.dart
@@ -56,6 +56,8 @@ class _SignMessageScreenState extends State<SignMessageScreen> {
     final l10n = l10nOf(context);
     if (!_canSign) return;
 
+    FocusScope.of(context).unfocus();
+
     final authenticated = await reAuthDialog(context);
     if (!authenticated) return;
     if (!mounted) return;

--- a/lib/pages/main/wallet_contents/verify_message.dart
+++ b/lib/pages/main/wallet_contents/verify_message.dart
@@ -167,11 +167,14 @@ class _VerifyMessageScreenState extends State<VerifyMessageScreen> {
                   ),
                   ThemedControls.transparentButtonSmall(
                     onPressed: () async {
+                      final focusScope = FocusScope.of(context);
                       final clipboardData =
                           await Clipboard.getData(Clipboard.kTextPlain);
                       if (clipboardData?.text != null) {
                         _verifyInputController.text = clipboardData!.text!;
                       }
+                      if (!mounted) return;
+                      focusScope.unfocus();
                     },
                     text: l10n.generalButtonPaste,
                   ),
@@ -182,6 +185,13 @@ class _VerifyMessageScreenState extends State<VerifyMessageScreen> {
                 controller: _verifyInputController,
                 maxLines: null,
                 minLines: 6,
+                textInputAction: TextInputAction.done,
+                onFieldSubmitted: (_) {
+                  FocusScope.of(context).unfocus();
+                  if (_verifyInputController.text.isNotEmpty) {
+                    _onVerify();
+                  }
+                },
                 decoration: ThemeInputDecorations.bigInputbox.copyWith(
                   hintText: l10n.signVerifyMessageVerifyInputPlaceholder,
                   suffixIcon: hasInput

--- a/lib/pages/main/wallet_contents/verify_message.dart
+++ b/lib/pages/main/wallet_contents/verify_message.dart
@@ -191,7 +191,8 @@ class _VerifyMessageScreenState extends State<VerifyMessageScreen> {
                     _onVerify();
                   }
                 },
-                decoration: ThemeInputDecorations.bigInputbox.copyWith(
+                decoration:
+                    ThemeInputDecorations.bigInputboxCompact.copyWith(
                   hintText: l10n.signVerifyMessageVerifyInputPlaceholder,
                   suffixIcon: hasInput
                       ? IconButton(

--- a/lib/pages/main/wallet_contents/verify_message.dart
+++ b/lib/pages/main/wallet_contents/verify_message.dart
@@ -167,14 +167,13 @@ class _VerifyMessageScreenState extends State<VerifyMessageScreen> {
                   ),
                   ThemedControls.transparentButtonSmall(
                     onPressed: () async {
-                      final focusScope = FocusScope.of(context);
+                      FocusScope.of(context).unfocus();
                       final clipboardData =
                           await Clipboard.getData(Clipboard.kTextPlain);
+                      if (!mounted) return;
                       if (clipboardData?.text != null) {
                         _verifyInputController.text = clipboardData!.text!;
                       }
-                      if (!mounted) return;
-                      focusScope.unfocus();
                     },
                     text: l10n.generalButtonPaste,
                   ),

--- a/lib/styles/input_decorations.dart
+++ b/lib/styles/input_decorations.dart
@@ -71,6 +71,10 @@ abstract class ThemeInputDecorations {
     fillColor: LightThemeColors.inputFieldBg,
   );
 
+  static InputDecoration bigInputboxCompact = bigInputbox.copyWith(
+    contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+  );
+
   static InputDecoration normalInputbox = InputDecoration(
     contentPadding:
         const EdgeInsets.only(left: 16, right: 16, top: 16, bottom: 10),


### PR DESCRIPTION
- Dismiss keyboard on Sign tap, Paste tap, and Verify submit
- Add a Done action to the verify keyboard that triggers verification
- Tighten content padding on the multi-line text areas (via new shared
  `bigInputboxCompact` decoration, default `bigInputbox` unchanged)