### PR TITLE
feat: warn Android 5/6 users that this is the last supported version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -51,7 +51,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         //minSdkVersion flutter.minSdkVersion
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/helpers/android_deprecation_dialog.dart
+++ b/lib/helpers/android_deprecation_dialog.dart
@@ -1,0 +1,96 @@
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:qubic_wallet/di.dart';
+import 'package:qubic_wallet/flutter_flow/theme_paddings.dart';
+import 'package:qubic_wallet/helpers/platform_helpers.dart';
+import 'package:qubic_wallet/l10n/l10n.dart';
+import 'package:qubic_wallet/resources/hive_storage.dart';
+import 'package:qubic_wallet/styles/text_styles.dart';
+import 'package:qubic_wallet/styles/themed_controls.dart';
+
+const int _minSupportedAndroidSdkNext = 24; // Android 7.0 (Nougat)
+
+/// Tracks whether we've already shown (or are showing) the dialog this app
+/// session, so a rapid second invocation doesn't stack two dialogs before
+/// the first ack is persisted.
+bool _shownThisSession = false;
+
+/// Shows a one-time popup informing users on Android 5/6 that this is the
+/// last supported version for their device. Only fires once per install.
+Future<void> maybeShowAndroidDeprecationDialog(BuildContext context) async {
+  if (!isAndroid) return;
+  if (_shownThisSession) return;
+  // Claim the slot synchronously so a second invocation during the awaits
+  // below can't race past the guard.
+  _shownThisSession = true;
+
+  final int sdkInt;
+  try {
+    final info = await DeviceInfoPlugin().androidInfo;
+    sdkInt = info.version.sdkInt;
+  } catch (_) {
+    _shownThisSession = false;
+    return;
+  }
+  if (sdkInt >= _minSupportedAndroidSdkNext) return;
+
+  final hive = getIt<HiveStorage>();
+  if (hive.getAndroidDeprecationDialogAcknowledged()) return;
+
+  if (!context.mounted) return;
+
+  final l10n = l10nOf(context);
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (ctx) => PopScope(
+      canPop: false,
+      child: AlertDialog(
+        surfaceTintColor: LightThemeColors.strongBackground,
+        title: Text(
+          l10n.androidDeprecationDialogTitle,
+          style: TextStyles.alertHeader,
+        ),
+        content: _buildBody(
+          l10n.androidDeprecationDialogMessageBefore,
+          l10n.androidDeprecationDialogMessageHighlight,
+          l10n.androidDeprecationDialogMessageAfter,
+        ),
+        actions: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 100),
+            child: ThemedControls.primaryButtonBig(
+              text: l10n.androidDeprecationDialogButton,
+              onPressed: () async {
+                await hive.setAndroidDeprecationDialogAcknowledged(true);
+                if (!ctx.mounted) return;
+                Navigator.of(ctx).pop();
+              },
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+Widget _buildBody(String before, String highlight, String after) {
+  final baseStyle = TextStyles.alertText.copyWith(fontSize: 16);
+  return RichText(
+    text: TextSpan(
+      style: baseStyle,
+      children: [
+        TextSpan(text: before),
+        TextSpan(
+          text: highlight,
+          style: baseStyle.copyWith(
+            fontWeight: FontWeight.bold,
+            decoration: TextDecoration.underline,
+          ),
+        ),
+        TextSpan(text: after),
+      ],
+    ),
+  );
+}

--- a/lib/helpers/android_deprecation_dialog.dart
+++ b/lib/helpers/android_deprecation_dialog.dart
@@ -1,10 +1,12 @@
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:qubic_wallet/di.dart';
 import 'package:qubic_wallet/flutter_flow/theme_paddings.dart';
 import 'package:qubic_wallet/helpers/platform_helpers.dart';
 import 'package:qubic_wallet/l10n/l10n.dart';
 import 'package:qubic_wallet/resources/hive_storage.dart';
+import 'package:qubic_wallet/styles/app_icons.dart';
 import 'package:qubic_wallet/styles/text_styles.dart';
 import 'package:qubic_wallet/styles/themed_controls.dart';
 
@@ -48,9 +50,27 @@ Future<void> maybeShowAndroidDeprecationDialog(BuildContext context) async {
       canPop: false,
       child: AlertDialog(
         surfaceTintColor: LightThemeColors.strongBackground,
-        title: Text(
-          l10n.androidDeprecationDialogTitle,
-          style: TextStyles.alertHeader,
+        title: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            SvgPicture.asset(
+              AppIcons.warning,
+              height: 56,
+              colorFilter: const ColorFilter.mode(
+                LightThemeColors.warning40,
+                BlendMode.srcIn,
+              ),
+            ),
+            ThemedControls.spacerVerticalSmall(),
+            Text(
+              l10n.androidDeprecationDialogTitle,
+              style: TextStyles.alertHeader.copyWith(
+                color: LightThemeColors.warning40,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
         ),
         content: _buildBody(
           l10n.androidDeprecationDialogMessageBefore,
@@ -76,7 +96,7 @@ Future<void> maybeShowAndroidDeprecationDialog(BuildContext context) async {
 }
 
 Widget _buildBody(String before, String highlight, String after) {
-  final baseStyle = TextStyles.alertText.copyWith(fontSize: 16);
+  final baseStyle = TextStyles.alertText;
   return RichText(
     text: TextSpan(
       style: baseStyle,

--- a/lib/helpers/android_deprecation_dialog.dart
+++ b/lib/helpers/android_deprecation_dialog.dart
@@ -1,16 +1,16 @@
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:qubic_wallet/di.dart';
 import 'package:qubic_wallet/flutter_flow/theme_paddings.dart';
 import 'package:qubic_wallet/helpers/platform_helpers.dart';
 import 'package:qubic_wallet/l10n/l10n.dart';
-import 'package:qubic_wallet/resources/hive_storage.dart';
 import 'package:qubic_wallet/styles/app_icons.dart';
 import 'package:qubic_wallet/styles/text_styles.dart';
 import 'package:qubic_wallet/styles/themed_controls.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 const int _minSupportedAndroidSdkNext = 24; // Android 7.0 (Nougat)
+const String _ackKey = 'android_deprecation_dialog_acknowledged_v1';
 
 /// Tracks whether we've already shown (or are showing) the dialog this app
 /// session, so a rapid second invocation doesn't stack two dialogs before
@@ -36,8 +36,14 @@ Future<void> maybeShowAndroidDeprecationDialog(BuildContext context) async {
   }
   if (sdkInt >= _minSupportedAndroidSdkNext) return;
 
-  final hive = getIt<HiveStorage>();
-  if (hive.getAndroidDeprecationDialogAcknowledged()) return;
+  final SharedPreferences prefs;
+  try {
+    prefs = await SharedPreferences.getInstance();
+  } catch (_) {
+    _shownThisSession = false;
+    return;
+  }
+  if (prefs.getBool(_ackKey) == true) return;
 
   if (!context.mounted) return;
 
@@ -83,7 +89,12 @@ Future<void> maybeShowAndroidDeprecationDialog(BuildContext context) async {
             child: ThemedControls.primaryButtonBig(
               text: l10n.androidDeprecationDialogButton,
               onPressed: () async {
-                await hive.setAndroidDeprecationDialogAcknowledged(true);
+                try {
+                  await prefs.setBool(_ackKey, true);
+                } catch (_) {
+                  // Best-effort persistence; still dismiss the dialog so the
+                  // user is not stuck on this non-dismissible modal.
+                }
                 if (!ctx.mounted) return;
                 Navigator.of(ctx).pop();
               },

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -905,5 +905,10 @@
     "signVerifyMessageErrorChecksum": "Prüfsumme der Signatur konnte nicht verifiziert werden.",
     "signVerifyMessageErrorSign": "Signieren der Nachricht fehlgeschlagen. Bitte erneut versuchen.",
     "signVerifyMessageSettingsLabel": "Nachricht verifizieren",
-    "signVerifyMessageAccountMenu": "Nachricht signieren"
+    "signVerifyMessageAccountMenu": "Nachricht signieren",
+    "androidDeprecationDialogTitle": "Wichtig: Hinweis zur Geräteaktualisierung",
+    "androidDeprecationDialogMessageBefore": "Zukünftige Updates erfordern Android 7.0 oder höher. Um weiterhin Updates zu erhalten und den langfristigen Zugriff auf Ihre Wallet zu sichern, ",
+    "androidDeprecationDialogMessageHighlight": "sichern Sie bitte Ihre privaten Seeds oder exportieren Sie Ihre Wallet-Vault-Datei",
+    "androidDeprecationDialogMessageAfter": " in den Einstellungen.",
+    "androidDeprecationDialogButton": "Verstanden"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1032,5 +1032,10 @@
     "signVerifyMessageErrorChecksum": "Signature checksum verification failed.",
     "signVerifyMessageErrorSign": "Failed to sign message. Please try again.",
     "signVerifyMessageSettingsLabel": "Verify Message",
-    "signVerifyMessageAccountMenu": "Sign Message"
+    "signVerifyMessageAccountMenu": "Sign Message",
+    "androidDeprecationDialogTitle": "Important: device update warning",
+    "androidDeprecationDialogMessageBefore": "Future updates will require Android 7.0 or higher. To continue receiving updates and ensure long-term wallet access, please ",
+    "androidDeprecationDialogMessageHighlight": "back up your private seeds or export your wallet vault",
+    "androidDeprecationDialogMessageAfter": " from Settings.",
+    "androidDeprecationDialogButton": "Got it"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -904,5 +904,10 @@
     "signVerifyMessageErrorChecksum": "No se pudo verificar la suma de comprobación de la firma.",
     "signVerifyMessageErrorSign": "No se pudo firmar el mensaje. Inténtalo de nuevo.",
     "signVerifyMessageSettingsLabel": "Verificar mensaje",
-    "signVerifyMessageAccountMenu": "Firmar mensaje"
+    "signVerifyMessageAccountMenu": "Firmar mensaje",
+    "androidDeprecationDialogTitle": "Importante: aviso de actualización del dispositivo",
+    "androidDeprecationDialogMessageBefore": "Las actualizaciones futuras requerirán Android 7.0 o superior. Para seguir recibiendo actualizaciones y asegurar el acceso a tu billetera a largo plazo, ",
+    "androidDeprecationDialogMessageHighlight": "respalda tus seeds privados o exporta tu archivo de bóveda",
+    "androidDeprecationDialogMessageAfter": " desde Ajustes.",
+    "androidDeprecationDialogButton": "Entendido"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -910,5 +910,10 @@
     "signVerifyMessageErrorChecksum": "Échec de la vérification de la somme de contrôle de la signature.",
     "signVerifyMessageErrorSign": "Échec de la signature du message. Veuillez réessayer.",
     "signVerifyMessageSettingsLabel": "Vérifier le message",
-    "signVerifyMessageAccountMenu": "Signer le message"
+    "signVerifyMessageAccountMenu": "Signer le message",
+    "androidDeprecationDialogTitle": "Important : avertissement de mise à jour de l'appareil",
+    "androidDeprecationDialogMessageBefore": "Les futures mises à jour nécessiteront Android 7.0 ou supérieur. Pour continuer à recevoir les mises à jour et garantir l'accès à long terme à votre portefeuille, veuillez ",
+    "androidDeprecationDialogMessageHighlight": "sauvegarder vos seeds privés ou exporter votre fichier de coffre",
+    "androidDeprecationDialogMessageAfter": " depuis les Paramètres.",
+    "androidDeprecationDialogButton": "Compris"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -905,5 +905,10 @@
     "signVerifyMessageErrorChecksum": "Проверка контрольной суммы подписи не удалась.",
     "signVerifyMessageErrorSign": "Не удалось подписать сообщение. Повторите попытку.",
     "signVerifyMessageSettingsLabel": "Проверить сообщение",
-    "signVerifyMessageAccountMenu": "Подписать сообщение"
+    "signVerifyMessageAccountMenu": "Подписать сообщение",
+    "androidDeprecationDialogTitle": "Важно: предупреждение об обновлении устройства",
+    "androidDeprecationDialogMessageBefore": "Будущие обновления потребуют Android 7.0 или выше. Чтобы продолжать получать обновления и обеспечить долгосрочный доступ к кошельку, ",
+    "androidDeprecationDialogMessageHighlight": "сохраните резервные копии приватных сидов или экспортируйте файл хранилища кошелька",
+    "androidDeprecationDialogMessageAfter": " в Настройках.",
+    "androidDeprecationDialogButton": "Понятно"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -905,5 +905,10 @@
     "signVerifyMessageErrorChecksum": "İmza sağlama toplamı doğrulanamadı.",
     "signVerifyMessageErrorSign": "Mesaj imzalanamadı. Lütfen tekrar deneyin.",
     "signVerifyMessageSettingsLabel": "Mesajı Doğrula",
-    "signVerifyMessageAccountMenu": "Mesajı İmzala"
+    "signVerifyMessageAccountMenu": "Mesajı İmzala",
+    "androidDeprecationDialogTitle": "Önemli: cihaz güncelleme uyarısı",
+    "androidDeprecationDialogMessageBefore": "Gelecek güncellemeler Android 7.0 veya üzerini gerektirecek. Güncellemeleri almaya devam etmek ve cüzdanınıza uzun vadeli erişimi güvence altına almak için lütfen Ayarlar bölümünden ",
+    "androidDeprecationDialogMessageHighlight": "özel seed'lerinizi yedekleyin veya cüzdan kasası dosyanızı dışa aktarın",
+    "androidDeprecationDialogMessageAfter": ".",
+    "androidDeprecationDialogButton": "Anladım"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -968,5 +968,10 @@
     "signVerifyMessageErrorChecksum": "Xác minh tổng kiểm tra chữ ký thất bại.",
     "signVerifyMessageErrorSign": "Không thể ký tin nhắn. Vui lòng thử lại.",
     "signVerifyMessageSettingsLabel": "Xác minh tin nhắn",
-    "signVerifyMessageAccountMenu": "Ký tin nhắn"
+    "signVerifyMessageAccountMenu": "Ký tin nhắn",
+    "androidDeprecationDialogTitle": "Quan trọng: cảnh báo cập nhật thiết bị",
+    "androidDeprecationDialogMessageBefore": "Các bản cập nhật trong tương lai sẽ yêu cầu Android 7.0 trở lên. Để tiếp tục nhận các bản cập nhật và đảm bảo quyền truy cập ví lâu dài, hãy ",
+    "androidDeprecationDialogMessageHighlight": "sao lưu seed riêng tư của bạn hoặc xuất tệp vault ví",
+    "androidDeprecationDialogMessageAfter": " từ Cài đặt.",
+    "androidDeprecationDialogButton": "Đã hiểu"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -905,5 +905,10 @@
     "signVerifyMessageErrorChecksum": "签名校验和验证失败。",
     "signVerifyMessageErrorSign": "签名消息失败。请重试。",
     "signVerifyMessageSettingsLabel": "验证消息",
-    "signVerifyMessageAccountMenu": "签名消息"
+    "signVerifyMessageAccountMenu": "签名消息",
+    "androidDeprecationDialogTitle": "重要：设备更新警告",
+    "androidDeprecationDialogMessageBefore": "未来的更新将需要 Android 7.0 或更高版本。为了继续接收更新并确保对钱包的长期访问，请从设置中",
+    "androidDeprecationDialogMessageHighlight": "备份您的私有种子或导出钱包保险库文件",
+    "androidDeprecationDialogMessageAfter": "。",
+    "androidDeprecationDialogButton": "知道了"
 }

--- a/lib/pages/main/main_screen.dart
+++ b/lib/pages/main/main_screen.dart
@@ -11,6 +11,7 @@ import 'package:qubic_wallet/components/change_foreground.dart';
 import 'package:qubic_wallet/config.dart';
 import 'package:qubic_wallet/di.dart';
 import 'package:qubic_wallet/flutter_flow/theme_paddings.dart';
+import 'package:qubic_wallet/helpers/android_deprecation_dialog.dart';
 import 'package:qubic_wallet/helpers/clipboard_helper.dart';
 import 'package:qubic_wallet/l10n/l10n.dart';
 import 'package:qubic_wallet/models/app_link/app_link_controller.dart';
@@ -234,6 +235,11 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       if (!mounted) return;
       appLinkController.parseUriString(
           applicationStore.currentInboundUri!, context);
+    });
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      maybeShowAndroidDeprecationDialog(context);
     });
   }
 

--- a/lib/resources/hive_storage.dart
+++ b/lib/resources/hive_storage.dart
@@ -19,7 +19,6 @@ enum HiveBoxesNames {
   accountsSortingMode,
   favoriteDapps,
   externalUrlWarningPreference,
-  androidDeprecationDialogPreference,
 }
 
 class HiveStorage {
@@ -29,12 +28,10 @@ class HiveStorage {
   late Box<String> _currentNetworkBox;
   late Box<FavoriteDappModel> _favoriteDapps;
   late Box<bool> _externalUrlWarningBox;
-  late Box<bool> _androidDeprecationDialogBox;
   final currentNetworkKey = "current_network";
   late Box<String> _accountsSortingMode;
   final accountsSortingKey = "accounts_sorting_mode";
   final externalUrlWarningKey = "external_url_warning_dismissed";
-  final androidDeprecationDialogKey = "android_deprecation_dialog_acknowledged";
   late HiveAesCipher _encryptionCipher;
 
   Future<void> initialize() async {
@@ -55,7 +52,6 @@ class HiveStorage {
       await openAccountsSortingModeBox();
       await openFavoriteDappsBox();
       await openExternalUrlWarningBox();
-      await openAndroidDeprecationDialogBox();
     } catch (e) {
       appLogger.e("[HiveStorage] Error initializing hive storage: $e");
     }
@@ -137,15 +133,6 @@ class HiveStorage {
     appLogger.d('[HiveStorage] External URL warning preference box opened.');
   }
 
-  Future<void> openAndroidDeprecationDialogBox() async {
-    _androidDeprecationDialogBox = await Hive.openBox<bool>(
-      HiveBoxesNames.androidDeprecationDialogPreference.name,
-      encryptionCipher: _encryptionCipher,
-    );
-    appLogger
-        .d('[HiveStorage] Android deprecation dialog preference box opened.');
-  }
-
   void addStoredTransaction(TransactionVm transactionVm) {
     appLogger.d('[HiveStorage] Adding transaction: ${transactionVm.id}');
     _storedTransactions.put(transactionVm.id, transactionVm);
@@ -213,19 +200,6 @@ class HiveStorage {
     _externalUrlWarningBox.put(externalUrlWarningKey, dismissed);
   }
 
-  // Android deprecation dialog preference methods
-  bool getAndroidDeprecationDialogAcknowledged() {
-    return _androidDeprecationDialogBox.get(androidDeprecationDialogKey) ??
-        false;
-  }
-
-  Future<void> setAndroidDeprecationDialogAcknowledged(bool acknowledged) async {
-    appLogger.d(
-        '[HiveStorage] Setting Android deprecation dialog acknowledged: $acknowledged');
-    await _androidDeprecationDialogBox
-        .put(androidDeprecationDialogKey, acknowledged);
-  }
-
   // Favorite dApps methods
   void addFavoriteDapp(FavoriteDappModel favorite) {
     appLogger.d('[HiveStorage] Adding favorite: ${favorite.name}');
@@ -288,9 +262,6 @@ class HiveStorage {
 
     await _externalUrlWarningBox.clear();
     _externalUrlWarningBox.close();
-
-    await _androidDeprecationDialogBox.clear();
-    _androidDeprecationDialogBox.close();
 
     await _secureStorage.deleteHiveEncryptionKey();
     appLogger.w(

--- a/lib/resources/hive_storage.dart
+++ b/lib/resources/hive_storage.dart
@@ -19,6 +19,7 @@ enum HiveBoxesNames {
   accountsSortingMode,
   favoriteDapps,
   externalUrlWarningPreference,
+  androidDeprecationDialogPreference,
 }
 
 class HiveStorage {
@@ -28,10 +29,12 @@ class HiveStorage {
   late Box<String> _currentNetworkBox;
   late Box<FavoriteDappModel> _favoriteDapps;
   late Box<bool> _externalUrlWarningBox;
+  late Box<bool> _androidDeprecationDialogBox;
   final currentNetworkKey = "current_network";
   late Box<String> _accountsSortingMode;
   final accountsSortingKey = "accounts_sorting_mode";
   final externalUrlWarningKey = "external_url_warning_dismissed";
+  final androidDeprecationDialogKey = "android_deprecation_dialog_acknowledged";
   late HiveAesCipher _encryptionCipher;
 
   Future<void> initialize() async {
@@ -52,6 +55,7 @@ class HiveStorage {
       await openAccountsSortingModeBox();
       await openFavoriteDappsBox();
       await openExternalUrlWarningBox();
+      await openAndroidDeprecationDialogBox();
     } catch (e) {
       appLogger.e("[HiveStorage] Error initializing hive storage: $e");
     }
@@ -133,6 +137,15 @@ class HiveStorage {
     appLogger.d('[HiveStorage] External URL warning preference box opened.');
   }
 
+  Future<void> openAndroidDeprecationDialogBox() async {
+    _androidDeprecationDialogBox = await Hive.openBox<bool>(
+      HiveBoxesNames.androidDeprecationDialogPreference.name,
+      encryptionCipher: _encryptionCipher,
+    );
+    appLogger
+        .d('[HiveStorage] Android deprecation dialog preference box opened.');
+  }
+
   void addStoredTransaction(TransactionVm transactionVm) {
     appLogger.d('[HiveStorage] Adding transaction: ${transactionVm.id}');
     _storedTransactions.put(transactionVm.id, transactionVm);
@@ -200,6 +213,19 @@ class HiveStorage {
     _externalUrlWarningBox.put(externalUrlWarningKey, dismissed);
   }
 
+  // Android deprecation dialog preference methods
+  bool getAndroidDeprecationDialogAcknowledged() {
+    return _androidDeprecationDialogBox.get(androidDeprecationDialogKey) ??
+        false;
+  }
+
+  Future<void> setAndroidDeprecationDialogAcknowledged(bool acknowledged) async {
+    appLogger.d(
+        '[HiveStorage] Setting Android deprecation dialog acknowledged: $acknowledged');
+    await _androidDeprecationDialogBox
+        .put(androidDeprecationDialogKey, acknowledged);
+  }
+
   // Favorite dApps methods
   void addFavoriteDapp(FavoriteDappModel favorite) {
     appLogger.d('[HiveStorage] Adding favorite: ${favorite.name}');
@@ -262,6 +288,9 @@ class HiveStorage {
 
     await _externalUrlWarningBox.clear();
     _externalUrlWarningBox.close();
+
+    await _androidDeprecationDialogBox.clear();
+    _androidDeprecationDialogBox.close();
 
     await _secureStorage.deleteHiveEncryptionKey();
     appLogger.w(

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import app_links
 import connectivity_plus
 import cryptography_flutter
+import device_info_plus
 import flutter_inappwebview_macos
 import flutter_is_ios_app_on_mac
 import flutter_secure_storage_macos
@@ -27,6 +28,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   CryptographyFlutterPlugin.register(with: registry.registrar(forPlugin: "CryptographyFlutterPlugin"))
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterIsIosAppOnMacPlugin.register(with: registry.registrar(forPlugin: "FlutterIsIosAppOnMacPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -385,6 +385,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.4"
+  device_info_plus:
+    dependency: "direct main"
+    description:
+      name: device_info_plus
+      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.2"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.3"
   dio:
     dependency: "direct main"
     description:
@@ -1089,10 +1105,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1694,10 +1710,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timeago:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,7 @@ dependencies:
   implicitly_animated_list: ^2.3.0
   cached_network_image: ^3.4.1
   pub_semver: ^2.1.5
+  device_info_plus: ^10.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Show a one-time popup on Android < 7.0 (SDK < 24) telling users to back up their private seeds or export their wallet vault before upgrading. The acknowledgement is persisted in an encrypted Hive box so the popup only shows once per install.

Hardcode minSdkVersion to 21 so Android 5/6 users can install this release. The next release will bump it to 24, after users have had this version's chance to back up.