### PR TITLE
feat: autofocus message field on sign-message screen

### DIFF
--- a/lib/pages/main/wallet_contents/sign_message.dart
+++ b/lib/pages/main/wallet_contents/sign_message.dart
@@ -126,6 +126,7 @@ class _SignMessageScreenState extends State<SignMessageScreen> {
               ThemedControls.spacerVerticalMini(),
               TextFormField(
                 controller: _messageController,
+                autofocus: true,
                 maxLines: 3,
                 decoration: ThemeInputDecorations.bigInputboxCompact.copyWith(
                   hintText: l10n.signVerifyMessageEnterMessage,


### PR DESCRIPTION
Saves the user one tap when they just want to type a message to sign.