### PR TITLE
chore: support 16 KB page sizes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ allprojects {
             if (project.plugins.hasPlugin("com.android.application") ||
                     project.plugins.hasPlugin("com.android.library")) {
                 project.android {
-                    compileSdkVersion 34
+                    compileSdkVersion 35
                     if (!project.android.hasProperty("namespace") || project.android.namespace == null) {
                         namespace project.group
                     }

--- a/lib/pages/main/wallet_contents/add_wallet_connect/components/add_wallet_connect_mobile_view.dart
+++ b/lib/pages/main/wallet_contents/add_wallet_connect/components/add_wallet_connect_mobile_view.dart
@@ -76,7 +76,7 @@ class _AddWalletConnectMobileViewState
                     torchEnabled: false,
                   ),
                   onDetect: widget.onDetect,
-                  errorBuilder: (context, error, child) {
+                  errorBuilder: (context, error) {
                     return Material(
                       child: Center(
                         child: Padding(

--- a/lib/services/qr_scanner_service.dart
+++ b/lib/services/qr_scanner_service.dart
@@ -92,7 +92,7 @@ class QrScannerService {
           children: [
             MobileScanner(
               controller: controller,
-              errorBuilder: (context, error, _) {
+              errorBuilder: (context, error) {
                 return Center(
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 50),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1121,10 +1121,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: d234581c090526676fd8fab4ada92f35c6746e3fb4f05a399665d75a399fb760
+      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.3"
+    version: "7.2.0"
   mobx:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   shimmer: ^3.0.0
   qr_flutter: ^4.1.0
   share_plus: ^10.0.2
-  mobile_scanner: ^5.1.1
+  mobile_scanner: ^7.2.0
   flutter_multi_formatter: ^2.11.11
   pagination_flutter: ^0.0.8
   sticky_headers: "^0.3.0"


### PR DESCRIPTION
Fix Android 16 KB page-size compliance by bumping mobile_scanner to 7.2.0 (aligns ML Kit + CameraX native libs).