### PR TITLE
feat: fetch assets from the aggregation endpoint instead of live per-address /owned

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -56,9 +56,15 @@ abstract class Config {
   static const submitTransaction = "$liveApiPrefix/broadcast-transaction";
   static addressQubicBalance(String address) =>
       "$liveApiPrefix/balances/$address";
-  static addressAssetsBalance(String address) =>
-      "$liveApiPrefix/assets/$address/owned";
   static const assets = "$liveApiPrefix/assets/issuances";
+
+  // ---------------------------------------------------------------------------
+  // RPC API Endpoints — Aggregation
+  // ---------------------------------------------------------------------------
+
+  static const aggregationApiPrefix = "/aggregation/v1";
+  static const getIdentitiesAssets =
+      "$aggregationApiPrefix/getIdentitiesAssets";
 
   // ---------------------------------------------------------------------------
   // RPC API Endpoints — Stats

--- a/lib/di.dart
+++ b/lib/di.dart
@@ -7,6 +7,7 @@ import 'package:qubic_wallet/models/wallet_connect/wallet_connect_modals_control
 import 'package:qubic_wallet/resources/apis/query/qubic_query_api.dart';
 import 'package:qubic_wallet/resources/apis/live/qubic_live_api.dart';
 import 'package:qubic_wallet/resources/apis/stats/qubic_stats_api.dart';
+import 'package:qubic_wallet/resources/apis/aggregation/qubic_aggregation_api.dart';
 import 'package:qubic_wallet/resources/hive_storage.dart';
 import 'package:qubic_wallet/resources/qubic_cmd.dart';
 import 'package:qubic_wallet/resources/secure_storage.dart';
@@ -32,6 +33,8 @@ Future<void> setupDI() async {
       QubicQueryApi(getIt<NetworkStore>()));
   getIt.registerSingleton<QubicLiveApi>(QubicLiveApi(getIt<NetworkStore>()));
   getIt.registerSingleton<QubicStatsApi>(QubicStatsApi(getIt<NetworkStore>()));
+  getIt.registerSingleton<QubicAggregationApi>(
+      QubicAggregationApi(getIt<NetworkStore>()));
   getIt.registerSingleton<QubicStaticApi>(QubicStaticApi());
 
   //Stores

--- a/lib/dtos/grouped_asset_dto.dart
+++ b/lib/dtos/grouped_asset_dto.dart
@@ -1,4 +1,4 @@
-import 'package:qubic_wallet/dtos/qubic_asset_dto.dart';
+import 'package:qubic_wallet/models/qubic_asset.dart';
 
 /// Represents a grouped asset (token) with all its managing contract contributions
 class GroupedAssetDto {
@@ -24,7 +24,7 @@ class GroupedAssetDto {
 class AssetContractContribution {
   final int managingContractIndex;
   final int numberOfUnits;
-  final QubicAssetDto sourceAsset;
+  final QubicAsset sourceAsset;
 
   AssetContractContribution({
     required this.managingContractIndex,

--- a/lib/dtos/identities_assets_response.dart
+++ b/lib/dtos/identities_assets_response.dart
@@ -1,10 +1,10 @@
-import 'package:qubic_wallet/dtos/qubic_asset_dto.dart';
+import 'package:qubic_wallet/models/qubic_asset.dart';
 
 /// Typed models for the `/aggregation/v1/getIdentitiesAssets` response.
 ///
 /// Mirrors the web wallet's `api.aggregation.model.ts`
 /// (`IdentityAssetRecord` / `IdentityAssetEntry` / `IdentitiesAssetsResponse`).
-/// The mapping to the app's [QubicAssetDto] lives in
+/// The mapping to the app's [QubicAsset] lives in
 /// [IdentitiesAssetsResponse.toOwnedAssets] so it can be unit-tested without
 /// the network layer.
 class IdentityAssetRecord {
@@ -71,15 +71,15 @@ class IdentitiesAssetsResponse {
             const [],
       );
 
-  /// Flattens every identity's **ownership** records into [QubicAssetDto]s,
+  /// Flattens every identity's **ownership** records into [QubicAsset]s,
   /// keeping only records with a positive share count. Possessions are ignored
   /// (owned-only, matching the prior `/owned` behavior and Angular's primary
   /// `ownedAmount`).
-  List<QubicAssetDto> toOwnedAssets() {
-    final List<QubicAssetDto> assets = [];
+  List<QubicAsset> toOwnedAssets() {
+    final List<QubicAsset> assets = [];
     for (final entry in identityAssets) {
       for (final record in entry.ownerships) {
-        final asset = QubicAssetDto.fromAggregation(
+        final asset = QubicAsset.fromAggregation(
           ownerIdentity: entry.identity,
           assetIssuer: record.assetIssuer,
           assetName: record.assetName,

--- a/lib/dtos/identities_assets_response.dart
+++ b/lib/dtos/identities_assets_response.dart
@@ -1,0 +1,97 @@
+import 'package:qubic_wallet/dtos/qubic_asset_dto.dart';
+
+/// Typed models for the `/aggregation/v1/getIdentitiesAssets` response.
+///
+/// Mirrors the web wallet's `api.aggregation.model.ts`
+/// (`IdentityAssetRecord` / `IdentityAssetEntry` / `IdentitiesAssetsResponse`).
+/// The mapping to the app's [QubicAssetDto] lives in
+/// [IdentitiesAssetsResponse.toOwnedAssets] so it can be unit-tested without
+/// the network layer.
+class IdentityAssetRecord {
+  final String assetIssuer;
+  final String assetName;
+  final int managingContractIndex;
+  final String numberOfShares;
+  final int tickNumber;
+
+  const IdentityAssetRecord({
+    required this.assetIssuer,
+    required this.assetName,
+    required this.managingContractIndex,
+    required this.numberOfShares,
+    required this.tickNumber,
+  });
+
+  factory IdentityAssetRecord.fromJson(Map<String, dynamic> json) =>
+      IdentityAssetRecord(
+        assetIssuer: json['assetIssuer'] as String? ?? '',
+        assetName: json['assetName'] as String? ?? '',
+        managingContractIndex: json['managingContractIndex'] as int? ?? 0,
+        numberOfShares: json['numberOfShares']?.toString() ?? '0',
+        tickNumber: json['tickNumber'] as int? ?? 0,
+      );
+}
+
+class IdentityAssetEntry {
+  final String identity;
+  final List<IdentityAssetRecord> ownerships;
+  final List<IdentityAssetRecord> possessions;
+
+  const IdentityAssetEntry({
+    required this.identity,
+    required this.ownerships,
+    required this.possessions,
+  });
+
+  factory IdentityAssetEntry.fromJson(Map<String, dynamic> json) =>
+      IdentityAssetEntry(
+        identity: json['identity'] as String? ?? '',
+        ownerships: _records(json['ownerships']),
+        possessions: _records(json['possessions']),
+      );
+
+  static List<IdentityAssetRecord> _records(dynamic list) =>
+      (list as List?)
+          ?.map((e) => IdentityAssetRecord.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const [];
+}
+
+class IdentitiesAssetsResponse {
+  final List<IdentityAssetEntry> identityAssets;
+
+  const IdentitiesAssetsResponse({required this.identityAssets});
+
+  factory IdentitiesAssetsResponse.fromJson(Map<String, dynamic> json) =>
+      IdentitiesAssetsResponse(
+        identityAssets: (json['identityAssets'] as List?)
+                ?.map((e) =>
+                    IdentityAssetEntry.fromJson(e as Map<String, dynamic>))
+                .toList() ??
+            const [],
+      );
+
+  /// Flattens every identity's **ownership** records into [QubicAssetDto]s,
+  /// keeping only records with a positive share count. Possessions are ignored
+  /// (owned-only, matching the prior `/owned` behavior and Angular's primary
+  /// `ownedAmount`).
+  List<QubicAssetDto> toOwnedAssets() {
+    final List<QubicAssetDto> assets = [];
+    for (final entry in identityAssets) {
+      for (final record in entry.ownerships) {
+        final asset = QubicAssetDto.fromAggregation(
+          ownerIdentity: entry.identity,
+          assetIssuer: record.assetIssuer,
+          assetName: record.assetName,
+          managingContractIndex: record.managingContractIndex,
+          numberOfShares: record.numberOfShares,
+          tickNumber: record.tickNumber,
+        );
+        if (asset.numberOfUnits > 0) {
+          assets.add(asset);
+        }
+      }
+    }
+    return assets;
+  }
+}

--- a/lib/dtos/qubic_asset_dto.dart
+++ b/lib/dtos/qubic_asset_dto.dart
@@ -1,41 +1,46 @@
 import 'package:qubic_wallet/smart_contracts/qx_info.dart';
 
-/// A Qubic asset representing asset data in the new format.
+/// A Qubic asset (one ownership position) as shown in the wallet.
+///
+/// Carries only the fields the UI consumes: the owner, the managing contract,
+/// the owned unit count, and the issued-asset name/issuer (plus the tick used
+/// to pick the latest record when de-duplicating). Built from the aggregation
+/// endpoint via [QubicAssetDto.fromAggregation].
 class QubicAssetDto {
   final String ownerIdentity;
-  final int type;
-  final int padding;
   final int managingContractIndex;
-  final int issuanceIndex;
   int numberOfUnits;
   final IssuedAsset issuedAsset;
   final AssetInfo info;
+
   QubicAssetDto({
     required this.ownerIdentity,
-    required this.type,
-    required this.padding,
     required this.managingContractIndex,
-    required this.issuanceIndex,
     required this.numberOfUnits,
     required this.issuedAsset,
     required this.info,
   });
+
   bool get isSmartContractShare =>
       issuedAsset.issuerIdentity == QxInfo.mainAssetIssuer;
 
-  factory QubicAssetDto.fromJson(Map<String, dynamic> json) {
-    final data = json['data'];
-    final info = json['info'];
-
+  factory QubicAssetDto.fromAggregation({
+    required String ownerIdentity,
+    required String assetIssuer,
+    required String assetName,
+    required int managingContractIndex,
+    required String numberOfShares,
+    required int tickNumber,
+  }) {
     return QubicAssetDto(
-      ownerIdentity: data['ownerIdentity'],
-      type: data['type'],
-      padding: data['padding'],
-      managingContractIndex: data['managingContractIndex'],
-      issuanceIndex: data['issuanceIndex'],
-      numberOfUnits: int.tryParse(data['numberOfUnits']) ?? 0,
-      issuedAsset: IssuedAsset.fromJson(data['issuedAsset']),
-      info: AssetInfo.fromJson(info),
+      ownerIdentity: ownerIdentity,
+      managingContractIndex: managingContractIndex,
+      numberOfUnits: int.tryParse(numberOfShares) ?? 0,
+      issuedAsset: IssuedAsset(
+        issuerIdentity: assetIssuer,
+        name: assetName,
+      ),
+      info: AssetInfo(tick: tickNumber),
     );
   }
 
@@ -53,10 +58,7 @@ class QubicAssetDto {
     if (identical(this, other)) return true;
 
     return other.ownerIdentity == ownerIdentity &&
-        other.type == type &&
-        other.padding == padding &&
         other.managingContractIndex == managingContractIndex &&
-        other.issuanceIndex == issuanceIndex &&
         other.numberOfUnits == numberOfUnits &&
         other.issuedAsset == issuedAsset &&
         other.info == info;
@@ -65,10 +67,7 @@ class QubicAssetDto {
   @override
   int get hashCode {
     return ownerIdentity.hashCode ^
-        type.hashCode ^
-        padding.hashCode ^
         managingContractIndex.hashCode ^
-        issuanceIndex.hashCode ^
         numberOfUnits.hashCode ^
         issuedAsset.hashCode ^
         info.hashCode;
@@ -77,43 +76,16 @@ class QubicAssetDto {
 
 class IssuedAsset {
   final String issuerIdentity;
-  final int type;
   final String name;
-  final int numberOfDecimalPlaces;
-  final List<int> unitOfMeasurement;
 
   IssuedAsset({
     required this.issuerIdentity,
-    required this.type,
     required this.name,
-    required this.numberOfDecimalPlaces,
-    required this.unitOfMeasurement,
   });
-
-  factory IssuedAsset.fromJson(Map<String, dynamic> json) {
-    return IssuedAsset(
-      issuerIdentity: json['issuerIdentity'],
-      type: json['type'],
-      name: json['name'],
-      numberOfDecimalPlaces: json['numberOfDecimalPlaces'],
-      unitOfMeasurement: List<int>.from(json['unitOfMeasurement']),
-    );
-  }
 }
 
 class AssetInfo {
   final int tick;
-  final int universeIndex;
 
-  AssetInfo({
-    required this.tick,
-    required this.universeIndex,
-  });
-
-  factory AssetInfo.fromJson(Map<String, dynamic> json) {
-    return AssetInfo(
-      tick: json['tick'],
-      universeIndex: json['universeIndex'],
-    );
-  }
+  AssetInfo({required this.tick});
 }

--- a/lib/models/qubic_asset.dart
+++ b/lib/models/qubic_asset.dart
@@ -5,15 +5,15 @@ import 'package:qubic_wallet/smart_contracts/qx_info.dart';
 /// Carries only the fields the UI consumes: the owner, the managing contract,
 /// the owned unit count, and the issued-asset name/issuer (plus the tick used
 /// to pick the latest record when de-duplicating). Built from the aggregation
-/// endpoint via [QubicAssetDto.fromAggregation].
-class QubicAssetDto {
+/// endpoint via [QubicAsset.fromAggregation].
+class QubicAsset {
   final String ownerIdentity;
   final int managingContractIndex;
   int numberOfUnits;
   final IssuedAsset issuedAsset;
   final AssetInfo info;
 
-  QubicAssetDto({
+  QubicAsset({
     required this.ownerIdentity,
     required this.managingContractIndex,
     required this.numberOfUnits,
@@ -24,7 +24,7 @@ class QubicAssetDto {
   bool get isSmartContractShare =>
       issuedAsset.issuerIdentity == QxInfo.mainAssetIssuer;
 
-  factory QubicAssetDto.fromAggregation({
+  factory QubicAsset.fromAggregation({
     required String ownerIdentity,
     required String assetIssuer,
     required String assetName,
@@ -32,7 +32,7 @@ class QubicAssetDto {
     required String numberOfShares,
     required int tickNumber,
   }) {
-    return QubicAssetDto(
+    return QubicAsset(
       ownerIdentity: ownerIdentity,
       managingContractIndex: managingContractIndex,
       numberOfUnits: int.tryParse(numberOfShares) ?? 0,
@@ -54,7 +54,7 @@ class QubicAssetDto {
   }
 
   @override
-  bool operator ==(covariant QubicAssetDto other) {
+  bool operator ==(covariant QubicAsset other) {
     if (identical(this, other)) return true;
 
     return other.ownerIdentity == ownerIdentity &&

--- a/lib/models/qubic_list_vm.dart
+++ b/lib/models/qubic_list_vm.dart
@@ -3,7 +3,7 @@ import 'dart:core';
 import 'package:hive/hive.dart';
 import 'package:mobx/mobx.dart';
 
-import 'package:qubic_wallet/dtos/qubic_asset_dto.dart';
+import 'package:qubic_wallet/models/qubic_asset.dart';
 import 'package:qubic_wallet/dtos/grouped_asset_dto.dart';
 
 @observable
@@ -19,7 +19,7 @@ class QubicListVm {
   late int? amountTick; //The tick when amount was valid for
 
   @observable
-  Map<String, QubicAssetDto> assets = {};
+  Map<String, QubicAsset> assets = {};
 
   @observable
   late bool? hasPendingTransaction;
@@ -28,7 +28,7 @@ class QubicListVm {
   late bool watchOnly;
 
   QubicListVm(String publicId, String name, this.amount, this.amountTick,
-      Map<String, QubicAssetDto>? assets, this.watchOnly) {
+      Map<String, QubicAsset>? assets, this.watchOnly) {
     _publicId = publicId.replaceAll(",", "_");
     _name = name.replaceAll(",", "_");
 
@@ -59,8 +59,8 @@ class QubicListVm {
   }
 
   /// Sets the number of shares (without mutation)
-  void setAssets(List<QubicAssetDto> newAssets) {
-    Map<String, QubicAssetDto> mergedAssets = {};
+  void setAssets(List<QubicAsset> newAssets) {
+    Map<String, QubicAsset> mergedAssets = {};
 
     for (int i = 0; i < newAssets.length; i++) {
       // Include issuer identity to distinguish tokens with same name but different issuers
@@ -75,15 +75,15 @@ class QubicListVm {
       }
     }
 
-    assets = Map<String, QubicAssetDto>.from(mergedAssets);
+    assets = Map<String, QubicAsset>.from(mergedAssets);
   }
 
-  Map<String, QubicAssetDto> getAssets() {
+  Map<String, QubicAsset> getAssets() {
     return assets;
   }
 
-  Map<String, QubicAssetDto> getClonedAssets() {
-    Map<String, QubicAssetDto> newShares = {};
+  Map<String, QubicAsset> getClonedAssets() {
+    Map<String, QubicAsset> newShares = {};
     assets.forEach((key, value) {
       newShares[key] = value;
     });
@@ -94,7 +94,7 @@ class QubicListVm {
   /// Assets are uniquely identified by the combination of issuer ID and asset name
   /// Contributions are sorted by number of units (highest first) for better UX
   List<GroupedAssetDto> getGroupedAssets() {
-    Map<String, List<QubicAssetDto>> groupedByToken = {};
+    Map<String, List<QubicAsset>> groupedByToken = {};
 
     // Group assets by token name AND issuer ID
     assets.forEach((key, asset) {
@@ -142,7 +142,7 @@ class QubicListVm {
         original.name,
         original.amount,
         original.amountTick,
-        Map<String, QubicAssetDto>.from(original.getClonedAssets()),
+        Map<String, QubicAsset>.from(original.getClonedAssets()),
         original.watchOnly);
   }
 }
@@ -157,8 +157,8 @@ class QubicListVmAdapter extends TypeAdapter<QubicListVm> {
     String name = reader.readString();
     int? amount = reader.read() as int?;
     int? amountTick = reader.read() as int?;
-    Map<String, QubicAssetDto> assets =
-        (reader.read() as Map).cast<String, QubicAssetDto>();
+    Map<String, QubicAsset> assets =
+        (reader.read() as Map).cast<String, QubicAsset>();
     bool watchOnly = reader.readBool();
 
     return QubicListVm(publicId, name, amount, amountTick, assets, watchOnly);

--- a/lib/resources/apis/aggregation/qubic_aggregation_api.dart
+++ b/lib/resources/apis/aggregation/qubic_aggregation_api.dart
@@ -1,0 +1,40 @@
+import 'package:dio/dio.dart';
+import 'package:qubic_wallet/config.dart';
+import 'package:qubic_wallet/dtos/identities_assets_response.dart';
+import 'package:qubic_wallet/dtos/qubic_asset_dto.dart';
+import 'package:qubic_wallet/models/app_error.dart';
+import 'package:qubic_wallet/services/dio_client.dart';
+import 'package:qubic_wallet/stores/network_store.dart';
+
+/// Client for the `/aggregation/v1` endpoints. Mirrors the web wallet's
+/// `ApiAggregationService`. Currently exposes owned-asset data via
+/// [getIdentitiesAssets] — one batched call for all identities, replacing the
+/// previous per-address `GET /live/v1/assets/{id}/owned`.
+class QubicAggregationApi {
+  late Dio _dio;
+  final NetworkStore _networkStore;
+
+  QubicAggregationApi(this._networkStore) {
+    _dio = DioClient.getDio(baseUrl: _networkStore.currentNetwork.rpcUrl);
+  }
+
+  void updateDio() {
+    _dio = DioClient.getDio(baseUrl: _networkStore.currentNetwork.rpcUrl);
+  }
+
+  Future<List<QubicAssetDto>> getIdentitiesAssets(
+      List<String> publicIds) async {
+    if (publicIds.isEmpty) return [];
+    try {
+      final response = await _dio.post(
+        '${_networkStore.currentNetwork.rpcUrl}${Config.getIdentitiesAssets}',
+        data: {'identities': publicIds},
+      );
+      return IdentitiesAssetsResponse.fromJson(
+              response.data as Map<String, dynamic>)
+          .toOwnedAssets();
+    } catch (e) {
+      throw await ErrorHandler.handleError(e);
+    }
+  }
+}

--- a/lib/resources/apis/aggregation/qubic_aggregation_api.dart
+++ b/lib/resources/apis/aggregation/qubic_aggregation_api.dart
@@ -1,7 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:qubic_wallet/config.dart';
 import 'package:qubic_wallet/dtos/identities_assets_response.dart';
-import 'package:qubic_wallet/dtos/qubic_asset_dto.dart';
+import 'package:qubic_wallet/models/qubic_asset.dart';
 import 'package:qubic_wallet/models/app_error.dart';
 import 'package:qubic_wallet/services/dio_client.dart';
 import 'package:qubic_wallet/stores/network_store.dart';
@@ -22,8 +22,7 @@ class QubicAggregationApi {
     _dio = DioClient.getDio(baseUrl: _networkStore.currentNetwork.rpcUrl);
   }
 
-  Future<List<QubicAssetDto>> getIdentitiesAssets(
-      List<String> publicIds) async {
+  Future<List<QubicAsset>> getIdentitiesAssets(List<String> publicIds) async {
     if (publicIds.isEmpty) return [];
     try {
       final response = await _dio.post(

--- a/lib/resources/apis/live/qubic_live_api.dart
+++ b/lib/resources/apis/live/qubic_live_api.dart
@@ -2,7 +2,6 @@ import 'package:dio/dio.dart';
 import 'package:qubic_wallet/config.dart';
 import 'package:qubic_wallet/dtos/current_balance_dto.dart';
 import 'package:qubic_wallet/dtos/current_tick_dto.dart';
-import 'package:qubic_wallet/dtos/qubic_asset_dto.dart';
 import 'package:qubic_wallet/models/app_error.dart';
 import 'package:qubic_wallet/models/token_response.dart';
 import 'package:qubic_wallet/services/dio_client.dart';
@@ -52,23 +51,6 @@ class QubicLiveApi {
       ]);
       return List<CurrentBalanceDto>.from(
           response.map((e) => CurrentBalanceDto.fromJson(e.data["balance"])));
-    } catch (e) {
-      throw await ErrorHandler.handleError(e);
-    }
-  }
-
-  Future<List<QubicAssetDto>> getCurrentAssets(List<String> publicIds) async {
-    try {
-      final response = await Future.wait([
-        for (var address in publicIds)
-          _dio.get(
-              '${_networkStore.currentNetwork.rpcUrl}${Config.addressAssetsBalance(address)}')
-      ]);
-      return response
-          .where((e) => e.data["ownedAssets"].isNotEmpty)
-          .expand((e) => (e.data["ownedAssets"] as List)
-              .map((asset) => QubicAssetDto.fromJson(asset)))
-          .toList();
     } catch (e) {
       throw await ErrorHandler.handleError(e);
     }

--- a/lib/services/wallet_connect_service.dart
+++ b/lib/services/wallet_connect_service.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:qubic_wallet/config.dart';
 import 'package:qubic_wallet/di.dart';
-import 'package:qubic_wallet/dtos/qubic_asset_dto.dart';
+import 'package:qubic_wallet/models/qubic_asset.dart';
 import 'package:qubic_wallet/helpers/app_logger.dart';
 import 'package:qubic_wallet/models/wallet_connect.dart';
 import 'package:qubic_wallet/models/wallet_connect/request_send_assets_event.dart';
@@ -119,8 +119,7 @@ class WalletConnectService {
   }
 
   /// Builds a list of asset items for WalletConnect JSON format.
-  List<dynamic> _buildAssetsListForWalletConnect(
-      Iterable<QubicAssetDto> assets) {
+  List<dynamic> _buildAssetsListForWalletConnect(Iterable<QubicAsset> assets) {
     return assets.map((asset) => asset.toWalletConnectJson()).toList();
   }
 
@@ -193,9 +192,9 @@ class WalletConnectService {
   }
 
 //Triggers an token amount change event for the wallet connect clients
-//@param changedIDs Map<String, List<QubicAssetDto>> (key = publicId) , List ,containes changed token amounts
+//@param changedIDs Map<String, List<QubicAsset>> (key = publicId) , List ,containes changed token amounts
   void triggerAssetAmountChangedEvent(
-      Map<String, List<QubicAssetDto>> changedIDs) {
+      Map<String, List<QubicAsset>> changedIDs) {
     if (!shouldTriggerEvent()) {
       return;
     }

--- a/lib/stores/application_store.dart
+++ b/lib/stores/application_store.dart
@@ -392,38 +392,6 @@ abstract class _ApplicationStore with Store {
   }
 
   @action
-  Future<void> setBalancesAndAssets(
-      List<CurrentBalanceDto> balances, List<QubicAsset> assets) async {
-    for (var i = 0; i < currentQubicIDs.length; i++) {
-      CurrentBalanceDto? balance =
-          balances.firstWhereOrNull((e) => e.id == currentQubicIDs[i].publicId);
-      List<QubicAsset> newAssets = assets
-          .where((e) => e.ownerIdentity == currentQubicIDs[i].publicId)
-          .toList();
-
-      if ((newAssets.isNotEmpty) || (balance != null)) {
-        var item = QubicListVm.clone(currentQubicIDs[i]);
-
-        if (newAssets.isNotEmpty) {
-          item.setAssets(newAssets);
-        }
-        if (balance != null) {
-          if ((item.amountTick == null) ||
-              (item.amountTick! < balance.validForTick)) {
-            item.amountTick = balance.validForTick;
-            item.amount = balance.balance;
-          }
-        }
-
-        currentQubicIDs[i] = item;
-      }
-    }
-    ObservableList<QubicListVm> newList = ObservableList<QubicListVm>();
-    newList.addAll(currentQubicIDs);
-    currentQubicIDs = newList;
-  }
-
-  @action
 
   /// Sets the $QUBIC amount for an account
   /// Returns the  IDs whose amounts have changed <PublicID, newAmount>

--- a/lib/stores/application_store.dart
+++ b/lib/stores/application_store.dart
@@ -7,7 +7,7 @@ import 'package:mobx/mobx.dart';
 import 'package:qubic_wallet/di.dart';
 import 'package:qubic_wallet/dtos/current_balance_dto.dart';
 import 'package:qubic_wallet/dtos/market_info_dto.dart';
-import 'package:qubic_wallet/dtos/qubic_asset_dto.dart';
+import 'package:qubic_wallet/models/qubic_asset.dart';
 import 'package:qubic_wallet/helpers/app_logger.dart';
 import 'package:qubic_wallet/models/qubic_id.dart';
 import 'package:qubic_wallet/models/qubic_list_vm.dart';
@@ -193,12 +193,12 @@ abstract class _ApplicationStore with Store {
   MarketInfoDto? marketInfo;
 
   @computed
-  List<QubicAssetDto> get totalShares {
-    List<QubicAssetDto> shares = [];
-    List<QubicAssetDto> tokens = [];
+  List<QubicAsset> get totalShares {
+    List<QubicAsset> shares = [];
+    List<QubicAsset> tokens = [];
     for (final id in nonWatchOnlyAccounts) {
       id.assets.forEach((key, asset) {
-        QubicAssetDto temp = asset;
+        QubicAsset temp = asset;
 
         if (asset.isSmartContractShare) {
           int index = shares.indexWhere(
@@ -222,7 +222,7 @@ abstract class _ApplicationStore with Store {
       });
     }
 
-    List<QubicAssetDto> result = [];
+    List<QubicAsset> result = [];
     result.addAll(shares);
     result.addAll(tokens);
 
@@ -393,11 +393,11 @@ abstract class _ApplicationStore with Store {
 
   @action
   Future<void> setBalancesAndAssets(
-      List<CurrentBalanceDto> balances, List<QubicAssetDto> assets) async {
+      List<CurrentBalanceDto> balances, List<QubicAsset> assets) async {
     for (var i = 0; i < currentQubicIDs.length; i++) {
       CurrentBalanceDto? balance =
           balances.firstWhereOrNull((e) => e.id == currentQubicIDs[i].publicId);
-      List<QubicAssetDto> newAssets = assets
+      List<QubicAsset> newAssets = assets
           .where((e) => e.ownerIdentity == currentQubicIDs[i].publicId)
           .toList();
 
@@ -457,13 +457,12 @@ abstract class _ApplicationStore with Store {
 
   /// Sets the Assets for an account
   /// Returns the list of IDs whose assets have changed
-  /// as <PublicID, [QubicAssetDto]>
-  Map<String, List<QubicAssetDto>> setAssets(
-      List<QubicAssetDto> assetsForAllIDs) {
-    Map<String, List<QubicAssetDto>> changedIds = {};
+  /// as <PublicID, [QubicAsset]>
+  Map<String, List<QubicAsset>> setAssets(List<QubicAsset> assetsForAllIDs) {
+    Map<String, List<QubicAsset>> changedIds = {};
 
     for (var i = 0; i < currentQubicIDs.length; i++) {
-      List<QubicAssetDto> assetsForID = assetsForAllIDs
+      List<QubicAsset> assetsForID = assetsForAllIDs
           .where((e) => e.ownerIdentity == currentQubicIDs[i].publicId)
           .toList();
       for (var j = 0; j < assetsForID.length; j++) {

--- a/lib/stores/application_store.g.dart
+++ b/lib/stores/application_store.g.dart
@@ -330,16 +330,6 @@ mixin _$ApplicationStore on _ApplicationStore, Store {
     return _$setNameAsyncAction.run(() => super.setName(publicId, name));
   }
 
-  late final _$setBalancesAndAssetsAsyncAction =
-      AsyncAction('_ApplicationStore.setBalancesAndAssets', context: context);
-
-  @override
-  Future<void> setBalancesAndAssets(
-      List<CurrentBalanceDto> balances, List<QubicAsset> assets) {
-    return _$setBalancesAndAssetsAsyncAction
-        .run(() => super.setBalancesAndAssets(balances, assets));
-  }
-
   late final _$validatePendingTransactionsAsyncAction = AsyncAction(
       '_ApplicationStore.validatePendingTransactions',
       context: context);

--- a/lib/stores/application_store.g.dart
+++ b/lib/stores/application_store.g.dart
@@ -30,11 +30,11 @@ mixin _$ApplicationStore on _ApplicationStore, Store {
           Computed<double>(() => super.totalAmountsInUSD,
               name: '_ApplicationStore.totalAmountsInUSD'))
       .value;
-  Computed<List<QubicAssetDto>>? _$totalSharesComputed;
+  Computed<List<QubicAsset>>? _$totalSharesComputed;
 
   @override
-  List<QubicAssetDto> get totalShares => (_$totalSharesComputed ??=
-          Computed<List<QubicAssetDto>>(() => super.totalShares,
+  List<QubicAsset> get totalShares => (_$totalSharesComputed ??=
+          Computed<List<QubicAsset>>(() => super.totalShares,
               name: '_ApplicationStore.totalShares'))
       .value;
 
@@ -335,7 +335,7 @@ mixin _$ApplicationStore on _ApplicationStore, Store {
 
   @override
   Future<void> setBalancesAndAssets(
-      List<CurrentBalanceDto> balances, List<QubicAssetDto> assets) {
+      List<CurrentBalanceDto> balances, List<QubicAsset> assets) {
     return _$setBalancesAndAssetsAsyncAction
         .run(() => super.setBalancesAndAssets(balances, assets));
   }

--- a/lib/stores/network_store.dart
+++ b/lib/stores/network_store.dart
@@ -5,6 +5,7 @@ import 'package:qubic_wallet/models/network_model.dart';
 import 'package:qubic_wallet/resources/apis/query/qubic_query_api.dart';
 import 'package:qubic_wallet/resources/apis/live/qubic_live_api.dart';
 import 'package:qubic_wallet/resources/apis/stats/qubic_stats_api.dart';
+import 'package:qubic_wallet/resources/apis/aggregation/qubic_aggregation_api.dart';
 import 'package:qubic_wallet/resources/hive_storage.dart';
 import 'package:qubic_wallet/stores/wallet_content_store.dart';
 
@@ -63,6 +64,7 @@ abstract class _NetworkStore with Store {
     getIt<QubicQueryApi>().updateDio();
     getIt<QubicLiveApi>().updateDio();
     getIt<QubicStatsApi>().updateDio();
+    getIt<QubicAggregationApi>().updateDio();
     try {
       getIt<WalletContentStore>()
           .allDapps

--- a/lib/timed_controller.dart
+++ b/lib/timed_controller.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:qubic_wallet/config.dart';
 import 'package:qubic_wallet/di.dart';
-import 'package:qubic_wallet/dtos/qubic_asset_dto.dart';
+import 'package:qubic_wallet/models/qubic_asset.dart';
 import 'package:qubic_wallet/models/app_error.dart';
 import 'package:qubic_wallet/resources/apis/query/qubic_query_api.dart';
 import 'package:qubic_wallet/resources/apis/live/qubic_live_api.dart';
@@ -91,10 +91,10 @@ class TimedController extends WidgetsBindingObserver {
   Future<void> _fetchAndProcessAssets(List<String> myIds) async {
     try {
       final assets = await _aggregationApi.getIdentitiesAssets(myIds);
-      final Map<String, List<QubicAssetDto>> changedIds =
+      final Map<String, List<QubicAsset>> changedIds =
           appStore.setAssets(assets);
 
-      final Map<String, List<QubicAssetDto>> changedIdsWithSeed = {};
+      final Map<String, List<QubicAsset>> changedIdsWithSeed = {};
 
       //Filter out only non WatchOnly accounts
       for (final element in changedIds.entries) {

--- a/lib/timed_controller.dart
+++ b/lib/timed_controller.dart
@@ -8,6 +8,7 @@ import 'package:qubic_wallet/models/app_error.dart';
 import 'package:qubic_wallet/resources/apis/query/qubic_query_api.dart';
 import 'package:qubic_wallet/resources/apis/live/qubic_live_api.dart';
 import 'package:qubic_wallet/resources/apis/stats/qubic_stats_api.dart';
+import 'package:qubic_wallet/resources/apis/aggregation/qubic_aggregation_api.dart';
 import 'package:qubic_wallet/services/wallet_connect_service.dart';
 import 'package:qubic_wallet/stores/application_store.dart';
 
@@ -24,6 +25,7 @@ class TimedController extends WidgetsBindingObserver {
   final _liveApi = getIt<QubicLiveApi>();
   final QubicStatsApi _statsApi = getIt<QubicStatsApi>();
   final QubicQueryApi _queryApi = getIt<QubicQueryApi>();
+  final QubicAggregationApi _aggregationApi = getIt<QubicAggregationApi>();
 
   stopFetchTimers() {
     if (_fetchTimer != null) {
@@ -88,7 +90,7 @@ class TimedController extends WidgetsBindingObserver {
 
   Future<void> _fetchAndProcessAssets(List<String> myIds) async {
     try {
-      final assets = await _liveApi.getCurrentAssets(myIds);
+      final assets = await _aggregationApi.getIdentitiesAssets(myIds);
       final Map<String, List<QubicAssetDto>> changedIds =
           appStore.setAssets(assets);
 

--- a/test/dtos/identities_assets_response_test.dart
+++ b/test/dtos/identities_assets_response_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qubic_wallet/dtos/identities_assets_response.dart';
+import 'package:qubic_wallet/smart_contracts/qx_info.dart';
+
+void main() {
+  group('IdentitiesAssetsResponse.fromJson', () {
+    test('coerces a numeric numberOfShares to a string', () {
+      // The live endpoint returns numberOfShares as a JSON number, not a string;
+      // the mapping relies on it being a String, so it must be coerced.
+      final entry = IdentitiesAssetsResponse.fromJson({
+        'identityAssets': [
+          {
+            'identity': 'X',
+            'ownerships': [
+              {
+                'assetIssuer': 'I',
+                'assetName': 'N',
+                'managingContractIndex': 0,
+                'numberOfShares': 1610000000,
+                'tickNumber': 0,
+              },
+            ],
+            'possessions': [],
+          },
+        ],
+      }).identityAssets.first;
+      expect(entry.ownerships.first.numberOfShares, '1610000000');
+    });
+
+    test('tolerates missing identityAssets / ownerships / possessions', () {
+      expect(IdentitiesAssetsResponse.fromJson({}).identityAssets, isEmpty);
+
+      final entry = IdentitiesAssetsResponse.fromJson({
+        'identityAssets': [
+          {'identity': 'X'},
+        ],
+      }).identityAssets.first;
+      expect(entry.ownerships, isEmpty);
+      expect(entry.possessions, isEmpty);
+    });
+  });
+
+  group('IdentitiesAssetsResponse.toOwnedAssets', () {
+    test(
+        'maps ownerships to owned assets; ignores possessions and drops zero shares',
+        () {
+      final assets = IdentitiesAssetsResponse.fromJson({
+        'identityAssets': [
+          {
+            'identity': 'IDENTITY_ONE',
+            'ownerships': [
+              {
+                'assetIssuer': 'ISSUER_A',
+                'assetName': 'ASSETA',
+                'managingContractIndex': 1,
+                'numberOfShares': '100',
+                'tickNumber': 5,
+              },
+              {
+                'assetIssuer': QxInfo.mainAssetIssuer,
+                'assetName': 'SHARE',
+                'managingContractIndex': 1,
+                'numberOfShares': '7',
+                'tickNumber': 6,
+              },
+              {
+                'assetIssuer': 'ISSUER_C',
+                'assetName': 'ZERO',
+                'managingContractIndex': 1,
+                'numberOfShares': '0',
+                'tickNumber': 4,
+              },
+            ],
+            'possessions': [
+              {
+                'assetIssuer': 'ISSUER_A',
+                'assetName': 'ASSETA',
+                'managingContractIndex': 1,
+                'numberOfShares': '999',
+                'tickNumber': 9,
+              },
+            ],
+          },
+          {
+            'identity': 'IDENTITY_TWO',
+            'ownerships': [
+              {
+                'assetIssuer': 'ISSUER_D',
+                'assetName': 'ASSETD',
+                'managingContractIndex': 2,
+                'numberOfShares': '50',
+                'tickNumber': 3,
+              },
+            ],
+            'possessions': [],
+          },
+        ],
+      }).toOwnedAssets();
+
+      // ownership rows with shares > 0: 100, 7, 50 -> 3 assets (0-share dropped)
+      expect(assets.length, 3);
+      // a possession amount must never leak into the result
+      expect(assets.any((a) => a.numberOfUnits == 999), isFalse);
+      // the zero-share ownership is filtered out
+      expect(assets.any((a) => a.issuedAsset.name == 'ZERO'), isFalse);
+
+      final assetA = assets.firstWhere((a) => a.issuedAsset.name == 'ASSETA');
+      expect(assetA.ownerIdentity, 'IDENTITY_ONE');
+      expect(assetA.numberOfUnits, 100); // owned, not possessed (999)
+      expect(assetA.issuedAsset.issuerIdentity, 'ISSUER_A');
+      expect(assetA.managingContractIndex, 1);
+      expect(assetA.info.tick, 5);
+      expect(assetA.isSmartContractShare, isFalse);
+
+      final share = assets.firstWhere((a) => a.issuedAsset.name == 'SHARE');
+      expect(share.numberOfUnits, 7);
+      expect(share.isSmartContractShare, isTrue);
+
+      final assetD = assets.firstWhere((a) => a.issuedAsset.name == 'ASSETD');
+      expect(assetD.ownerIdentity, 'IDENTITY_TWO');
+      expect(assetD.numberOfUnits, 50);
+      expect(assetD.managingContractIndex, 2);
+      expect(assetD.info.tick, 3);
+    });
+  });
+}


### PR DESCRIPTION
Switches wallet-app asset fetching from N× GET /live/v1/assets/{id}/owned to a single POST /aggregation/v1/getIdentitiesAssets (same source as the web wallet); values are unchanged. Also renames the now-misnamed QubicAssetDto → QubicAsset (a domain model, not a backend DTO) and moves it to lib/models.
